### PR TITLE
Handle root path correctly in router

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -26,6 +26,9 @@ final class Router
 
     private function compile(string $path): string
     {
+        if ($path === '/') {
+            return '#^/$#';
+        }
         $regex = preg_replace('#\{([a-zA-Z_][a-zA-Z0-9_]*)\}#', '(?P<$1>[^/]+)', $path);
         return '#^' . rtrim($regex, '/') . '$#';
     }


### PR DESCRIPTION
## Summary
- Ensure Router compiles root path '/' to regex `#^/$#`

## Testing
- `php -l app/Core/Router.php`
- `REQUEST_URI=/ REQUEST_METHOD=GET php public/index.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdc768bbc883289807fd5c1e1b13ce