### PR TITLE
Expose verified status in admin verification list

### DIFF
--- a/app/Controllers/AdminController.php
+++ b/app/Controllers/AdminController.php
@@ -1692,7 +1692,7 @@ final class AdminController
         $total = (int)$st->fetchColumn();
 
         $sql = "SELECT candidate_id, full_name, email, verification_doc_type, verification_doc_url,
-                   verification_date, verification_state, verification_review_notes
+                   verification_date, verification_state, verification_review_notes, verified_status
             FROM candidates
             $wsql
             ORDER BY verification_date DESC, candidate_id DESC
@@ -1774,7 +1774,7 @@ final class AdminController
 
         $pdo = \App\Core\DB::conn();
         $st = $pdo->prepare("UPDATE candidates
-                         SET verified_status=0,
+                         SET verified_status=2,
                              verification_state='Rejected',
                              verification_review_notes=:n,
                              verification_reviewed_at=NOW(),


### PR DESCRIPTION
## Summary
- Include `verified_status` in admin verification query
- Mark rejected candidates with `verified_status` 2 so list can show rejections

## Testing
- `php -l app/Controllers/AdminController.php`
- Approve candidate via AdminController::verifApprove and confirm `verified_status=1`
- Reject candidate via AdminController::verifReject and confirm `verified_status=2`


------
https://chatgpt.com/codex/tasks/task_e_68c475fabe0c832881aa8cfeb910358c