### PR TITLE
Centralize bootstrap initialization for app services

### DIFF
--- a/app/Core/Container.php
+++ b/app/Core/Container.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+/**
+ * Simple dependency injection container.
+ */
+final class Container
+{
+    /** @var array<string,mixed> */
+    private array $entries = [];
+
+    /**
+     * Register a value or factory with the container.
+     *
+     * @param string $id
+     * @param mixed $value
+     */
+    public function set(string $id, mixed $value): void
+    {
+        $this->entries[$id] = $value;
+    }
+
+    /**
+     * Retrieve a value from the container.
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function get(string $id): mixed
+    {
+        return $this->entries[$id] ?? null;
+    }
+}

--- a/app/Core/Middleware.php
+++ b/app/Core/Middleware.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+/**
+ * Registry for shared middleware callables.
+ */
+final class Middleware
+{
+    /** @var array<int,callable> */
+    private static array $stack = [];
+
+    /**
+     * Add a middleware to the global stack.
+     */
+    public static function add(callable $middleware): void
+    {
+        self::$stack[] = $middleware;
+    }
+
+    /**
+     * Run all registered middleware.
+     */
+    public static function run(): void
+    {
+        foreach (self::$stack as $mw) {
+            $mw();
+        }
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Core\Container;
+use App\Core\DB;
+use App\Core\Middleware;
+
+$root = __DIR__;
+
+// -----------------------------------------------------------------------------
+// Autoloading (Composer + PSR-4 for App\)
+// -----------------------------------------------------------------------------
+$vendor = $root . '/vendor/autoload.php';
+if (is_file($vendor)) {
+    require $vendor;
+}
+
+spl_autoload_register(function (string $class): void {
+    $prefix  = 'App\\';
+    $baseDir = __DIR__ . '/app/';
+    $len     = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) return;
+    $relative = substr($class, $len);
+    $file     = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) require $file;
+});
+
+// -----------------------------------------------------------------------------
+// Environment loading (.env)
+// -----------------------------------------------------------------------------
+$envFile = $root . '/.env';
+if (is_file($envFile)) {
+    $lines = file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || strncmp($line, '#', 1) === 0) {
+            continue;
+        }
+        [$name, $value] = array_map('trim', explode('=', $line, 2));
+        if (!array_key_exists($name, $_ENV)) {
+            putenv("$name=$value");
+            $_ENV[$name] = $value;
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Configuration loading
+// -----------------------------------------------------------------------------
+$config = require $root . '/config/config.php';
+
+// -----------------------------------------------------------------------------
+// Error handling
+// -----------------------------------------------------------------------------
+ini_set('display_errors', $config['app']['display_errors'] ?? '1');
+error_reporting($config['app']['error_level'] ?? E_ALL);
+set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
+    throw new \ErrorException($message, 0, $severity, $file, $line);
+});
+set_exception_handler(function (\Throwable $e): void {
+    error_log((string) $e);
+    http_response_code(500);
+    echo 'Application error';
+});
+
+date_default_timezone_set($_ENV['APP_TZ'] ?? 'Asia/Kuala_Lumpur');
+
+// -----------------------------------------------------------------------------
+// Session
+// -----------------------------------------------------------------------------
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// -----------------------------------------------------------------------------
+// Base URL calculation
+// -----------------------------------------------------------------------------
+define('BASE_URL', rtrim(str_replace('\\\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? '')), '/') ?: '');
+
+// -----------------------------------------------------------------------------
+// Dependency container & ORM initialisation
+// -----------------------------------------------------------------------------
+$container = new Container();
+$container->set('config', $config);
+$container->set('db', DB::conn());
+
+// Shared middleware registry (none yet but ready for expansion)
+Middleware::run();
+
+return $container;

--- a/public/index.php
+++ b/public/index.php
@@ -1,28 +1,6 @@
 <?php
 
 declare(strict_types=1);
-$vendor = dirname(__DIR__) . '/vendor/autoload.php';
-if (is_file($vendor)) {
-    require $vendor;
-}
-ini_set('display_errors', '1');
-error_reporting(E_ALL);
-date_default_timezone_set('Asia/Kuala_Lumpur');
-session_start();
-
-// Compute BASE_URL for subfolder installs (e.g. /HireMe/public)
-define('BASE_URL', rtrim(str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? '')), '/') ?: '');
-
-// PSR-4 autoloader for App\
-spl_autoload_register(function (string $class): void {
-    $prefix  = 'App\\';
-    $baseDir = dirname(__DIR__) . '/app/';
-    $len     = strlen($prefix);
-    if (strncmp($prefix, $class, $len) !== 0) return;
-    $relative = substr($class, $len);
-    $file     = $baseDir . str_replace('\\', '/', $relative) . '.php';
-    if (is_file($file)) require $file;
-});
 
 use App\Core\Router;
 use App\Controllers\HomeController;
@@ -36,6 +14,8 @@ use App\Controllers\ApplicationController;
 use App\Controllers\PaymentController;
 use App\Controllers\RecruiterCompaniesController;
 use App\Controllers\AdminController;
+
+$container = require dirname(__DIR__) . '/bootstrap.php';
 
 $router = new Router();
 


### PR DESCRIPTION
## Summary
- add bootstrap that loads env, config, sessions, and database into a container
- wire up simple container and middleware registry for shared dependencies
- require bootstrap in public index before defining routes

## Testing
- `php -l bootstrap.php`
- `php -l public/index.php`
- `php -l app/Core/Container.php`
- `php -l app/Core/Middleware.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6db79866083289d7924b2a15f0044