### PR TITLE
Refactor job creation to service layer

### DIFF
--- a/app/Core/DB.php
+++ b/app/Core/DB.php
@@ -11,6 +11,16 @@ final class DB
 {
     private static ?PDO $pdo = null;
 
+    /**
+     * Allow tests or services to override the active PDO connection.
+     * This enables using in-memory databases during testing while the
+     * application continues to retrieve connections via DB::conn().
+     */
+    public static function setConnection(PDO $pdo): void
+    {
+        self::$pdo = $pdo;
+    }
+
     public static function conn(): PDO
     {
         if (self::$pdo instanceof PDO) return self::$pdo;

--- a/app/Models/JobPosting.php
+++ b/app/Models/JobPosting.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Core\DB;
+use PDO;
+
+/**
+ * Basic active record style model for the job_postings table.
+ * Only the operations required by JobService are implemented.
+ */
+final class JobPosting
+{
+    /**
+     * Create a new job posting record.
+     *
+     * @param array{cid:int,rid:?int,title:string,desc:string,reqs:?string,loc:?string,langs:?string,etype:string,smin:?string,posted:string,ca:string,ua:string} $data
+     * @return int The newly created job ID
+     */
+    public static function create(array $data): int
+    {
+        $pdo = DB::conn();
+
+        $sql = "INSERT INTO job_postings
+            (company_id, recruiter_id, job_title, job_description, job_requirements, job_location, job_languages,
+             employment_type, salary_range_min, salary_range_max, application_deadline, date_posted, status,
+             number_of_positions, required_experience, education_level, created_at, updated_at)
+            VALUES
+            (:cid, :rid, :title, :desc, :reqs, :loc, :langs,
+             :etype, :smin, NULL, NULL, :posted, 'Open',
+             1, NULL, NULL, :ca, :ua)";
+
+        $st = $pdo->prepare($sql);
+        $st->execute([
+            ':cid'    => $data['cid'],
+            ':rid'    => $data['rid'],
+            ':title'  => $data['title'],
+            ':desc'   => $data['desc'],
+            ':reqs'   => $data['reqs'],
+            ':loc'    => $data['loc'],
+            ':langs'  => $data['langs'],
+            ':etype'  => $data['etype'],
+            ':smin'   => $data['smin'],
+            ':posted' => $data['posted'],
+            ':ca'     => $data['ca'],
+            ':ua'     => $data['ua'],
+        ]);
+
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Attach the chosen micro questions to the job posting.
+     *
+     * @param int   $jobId       Job posting ID
+     * @param int[] $questionIds Selected micro question IDs
+     */
+    public static function attachQuestions(int $jobId, array $questionIds): void
+    {
+        if (!$questionIds) {
+            return;
+        }
+
+        $pdo = DB::conn();
+        $ins = $pdo->prepare("INSERT INTO job_micro_questions (job_posting_id, question_id) VALUES (:jid, :qid)");
+        foreach ($questionIds as $qid) {
+            $ins->execute([':jid' => $jobId, ':qid' => $qid]);
+        }
+    }
+}
+

--- a/tests/JobServiceTest.php
+++ b/tests/JobServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) return;
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) require $file;
+});
+
+use App\Services\JobService;
+use App\Core\DB;
+
+// set up an in-memory sqlite database for testing
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->exec('CREATE TABLE job_postings (
+    job_posting_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company_id INTEGER,
+    recruiter_id INTEGER,
+    job_title TEXT,
+    job_description TEXT,
+    job_requirements TEXT,
+    job_location TEXT,
+    job_languages TEXT,
+    employment_type TEXT,
+    salary_range_min REAL,
+    salary_range_max REAL,
+    application_deadline TEXT,
+    date_posted TEXT,
+    status TEXT,
+    number_of_positions INTEGER,
+    required_experience TEXT,
+    education_level TEXT,
+    created_at TEXT,
+    updated_at TEXT
+);');
+$pdo->exec('CREATE TABLE job_micro_questions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_posting_id INTEGER,
+    question_id INTEGER
+);');
+
+DB::setConnection($pdo);
+
+$service = new JobService();
+[$jobId, $errors] = $service->create('Employer', 1, [
+    'job_title' => 'Example job',
+    'job_description' => 'Description',
+    'salary' => '1200',
+    'employment_type' => 'Full-time',
+    'mi_questions' => [1, 2, 3],
+]);
+
+assert(empty($errors), 'No validation errors expected');
+assert($jobId === 1, 'Job ID should be 1');
+
+echo "JobService tests passed\n";
+


### PR DESCRIPTION
## Summary
- Move job posting creation logic from `JobController` into new `JobService` and `JobPosting` model
- Allow overriding DB connection for tests via `DB::setConnection`
- Add basic unit test exercising job creation with an in-memory SQLite database

## Testing
- `php tests/JobServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c6db78e9a48328b2a48544f6460d21