### PR TITLE
Refactor services and models to use ORM

### DIFF
--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+class Application extends BaseModel
+{
+    protected $table = 'applications';
+    protected $primaryKey = 'applicant_id';
+
+    public function candidate()
+    {
+        return $this->belongsTo(Candidate::class, 'candidate_id', 'candidate_id');
+    }
+
+    public function jobPosting()
+    {
+        return $this->belongsTo(JobPosting::class, 'job_posting_id', 'job_posting_id');
+    }
+}

--- a/app/Models/JobPosting.php
+++ b/app/Models/JobPosting.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Capsule\Manager as Capsule;
+
 class JobPosting extends BaseModel
 {
     protected $table = 'job_postings';
@@ -30,5 +32,20 @@ class JobPosting extends BaseModel
     public function employer()
     {
         return $this->belongsTo(Employer::class, 'company_id', 'employer_id');
+    }
+
+    public function recruiter()
+    {
+        return $this->belongsTo(Recruiter::class, 'recruiter_id', 'recruiter_id');
+    }
+
+    public static function attachQuestions(int $jobId, array $questionIds): void
+    {
+        if (!$questionIds) return;
+        $rows = array_map(
+            fn($id) => ['job_posting_id' => $jobId, 'question_id' => $id],
+            $questionIds
+        );
+        Capsule::table('job_micro_questions')->insert($rows);
     }
 }

--- a/app/Models/Recruiter.php
+++ b/app/Models/Recruiter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+class Recruiter extends BaseModel
+{
+    protected $table = 'recruiters';
+    protected $primaryKey = 'recruiter_id';
+
+    public function jobPostings()
+    {
+        return $this->hasMany(JobPosting::class, 'recruiter_id', 'recruiter_id');
+    }
+}

--- a/app/Services/Notify.php
+++ b/app/Services/Notify.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Core\DB;
 use App\Core\Mailer;
-use PDO;
+use App\Models\Application;
+use App\Models\Candidate;
 use Throwable;
 
 final class Notify
@@ -24,50 +24,37 @@ final class Notify
     /** On new application (or re-apply): notify employer/recruiter + confirmation to candidate. */
     public static function onApplicationCreated(int $applicantId): void
     {
-        $pdo = DB::conn();
-        $sql = "
-            SELECT a.applicant_id, a.candidate_id, a.job_posting_id, a.application_date,
-                   c.full_name AS cand_name, c.email AS cand_email,
-                   jp.job_title, jp.company_id, jp.recruiter_id,
-                   e.company_name, e.email AS emp_email,
-                   r.full_name AS rec_name, r.email AS rec_email
-            FROM applications a
-            JOIN candidates  c  ON c.candidate_id = a.candidate_id
-            JOIN job_postings jp ON jp.job_posting_id = a.job_posting_id
-            JOIN employers   e  ON e.employer_id   = jp.company_id
-            LEFT JOIN recruiters r ON r.recruiter_id = jp.recruiter_id
-            WHERE a.applicant_id = :id
-            LIMIT 1
-        ";
-        $st = $pdo->prepare($sql);
-        $st->execute([':id' => $applicantId]);
-        $row = $st->fetch();
-        if (!$row) return;
+        $app = Application::with(['candidate', 'jobPosting.employer', 'jobPosting.recruiter'])
+            ->find($applicantId);
+        if (!$app || !$app->candidate || !$app->jobPosting) return;
 
-        $job     = (string)$row['job_title'];
-        $cname   = (string)$row['cand_name'];
-        $cemail  = (string)$row['cand_email'];
-        $company = (string)$row['company_name'];
-        $emp     = (string)$row['emp_email'];
-        $recName = (string)($row['rec_name'] ?? '');
-        $rec     = (string)($row['rec_email'] ?? '');
+        $candidate = $app->candidate;
+        $job       = $app->jobPosting;
+        $employer  = $job->employer;
+        $recruiter = $job->recruiter;
 
-        // To employer/recruiter
-        $to = array_values(array_filter([$emp, $rec])); // notify both if recruiter exists
+        $jobTitle = (string)$job->job_title;
+        $cname    = (string)$candidate->full_name;
+        $cemail   = (string)$candidate->email;
+        $company  = (string)($employer->company_name ?? '');
+        $emp      = (string)($employer->email ?? '');
+        $recName  = (string)($recruiter->full_name ?? '');
+        $rec      = (string)($recruiter->email ?? '');
+
+        $to = array_values(array_filter([$emp, $rec]));
         if ($to) {
-            $sub  = "[HireMe] New application for {$job}";
-            $html = "<p>Hi,</p>
-                     <p><strong>{$cname}</strong> just applied to <strong>{$job}</strong> at <strong>{$company}</strong>.</p>
-                     <p>Log in to review, shortlist, or schedule interviews.</p>";
+            $sub  = "[HireMe] New application for {$jobTitle}";
+            $html = "<p>Hi,</p>"
+                   . "<p><strong>{$cname}</strong> just applied to <strong>{$jobTitle}</strong> at <strong>{$company}</strong>.</p>"
+                   . "<p>Log in to review, shortlist, or schedule interviews.</p>";
             self::send($to, $sub, $html);
         }
 
-        // Confirmation to candidate
         if ($cemail) {
-            $sub  = "[HireMe] Application received — {$job} @ {$company}";
-            $html = "<p>Hi {$cname},</p>
-                     <p>We’ve received your application for <strong>{$job}</strong> at <strong>{$company}</strong>.</p>
-                     <p>We’ll let you know once the employer updates your status.</p>";
+            $sub  = "[HireMe] Application received — {$jobTitle} @ {$company}";
+            $html = "<p>Hi {$cname},</p>"
+                   . "<p>We’ve received your application for <strong>{$jobTitle}</strong> at <strong>{$company}</strong>.</p>"
+                   . "<p>We’ll let you know once the employer updates your status.</p>";
             self::send($cemail, $sub, $html);
         }
     }
@@ -75,44 +62,34 @@ final class Notify
     /** On withdraw: notify employer/recruiter + confirmation to candidate. */
     public static function onApplicationWithdrawn(int $applicantId): void
     {
-        $pdo = DB::conn();
-        $st = $pdo->prepare("
-            SELECT a.applicant_id, a.candidate_id, a.job_posting_id, a.application_date,
-                   c.full_name AS cand_name, c.email AS cand_email,
-                   jp.job_title, jp.company_id, jp.recruiter_id,
-                   e.company_name, e.email AS emp_email,
-                   r.full_name AS rec_name, r.email AS rec_email
-            FROM applications a
-            JOIN candidates  c  ON c.candidate_id = a.candidate_id
-            JOIN job_postings jp ON jp.job_posting_id = a.job_posting_id
-            JOIN employers   e  ON e.employer_id   = jp.company_id
-            LEFT JOIN recruiters r ON r.recruiter_id = jp.recruiter_id
-            WHERE a.applicant_id = :id
-            LIMIT 1
-        ");
-        $st->execute([':id' => $applicantId]);
-        $row = $st->fetch();
-        if (!$row) return;
+        $app = Application::with(['candidate', 'jobPosting.employer', 'jobPosting.recruiter'])
+            ->find($applicantId);
+        if (!$app || !$app->candidate || !$app->jobPosting) return;
 
-        $job     = (string)$row['job_title'];
-        $cname   = (string)$row['cand_name'];
-        $cemail  = (string)$row['cand_email'];
-        $company = (string)$row['company_name'];
-        $emp     = (string)$row['emp_email'];
-        $rec     = (string)($row['rec_email'] ?? '');
+        $candidate = $app->candidate;
+        $job       = $app->jobPosting;
+        $employer  = $job->employer;
+        $recruiter = $job->recruiter;
+
+        $jobTitle = (string)$job->job_title;
+        $cname    = (string)$candidate->full_name;
+        $cemail   = (string)$candidate->email;
+        $company  = (string)($employer->company_name ?? '');
+        $emp      = (string)($employer->email ?? '');
+        $rec      = (string)($recruiter->email ?? '');
 
         $to = array_values(array_filter([$emp, $rec]));
         if ($to) {
-            $sub  = "[HireMe] Application withdrawn — {$job}";
-            $html = "<p>Hi,</p>
-                     <p><strong>{$cname}</strong> has withdrawn their application for <strong>{$job}</strong> at <strong>{$company}</strong>.</p>";
+            $sub  = "[HireMe] Application withdrawn — {$jobTitle}";
+            $html = "<p>Hi,</p>"
+                   . "<p><strong>{$cname}</strong> has withdrawn their application for <strong>{$jobTitle}</strong> at <strong>{$company}</strong>.</p>";
             self::send($to, $sub, $html);
         }
 
         if ($cemail) {
-            $sub  = "[HireMe] You have withdrawn your application — {$job}";
-            $html = "<p>Hi {$cname},</p>
-                     <p>Your application for <strong>{$job}</strong> at <strong>{$company}</strong> was withdrawn.</p>";
+            $sub  = "[HireMe] You have withdrawn your application — {$jobTitle}";
+            $html = "<p>Hi {$cname},</p>"
+                   . "<p>Your application for <strong>{$jobTitle}</strong> at <strong>{$company}</strong> was withdrawn.</p>";
             self::send($cemail, $sub, $html);
         }
     }
@@ -120,56 +97,45 @@ final class Notify
     /** When employer/recruiter updates an application status (Interview/Rejected/etc.) — email candidate. */
     public static function onApplicationStatusChanged(int $applicantId, string $newStatus): void
     {
-        $pdo = DB::conn();
-        $st = $pdo->prepare("
-            SELECT a.applicant_id, a.application_status,
-                   c.full_name AS cand_name, c.email AS cand_email,
-                   jp.job_title, e.company_name
-            FROM applications a
-            JOIN candidates  c  ON c.candidate_id = a.candidate_id
-            JOIN job_postings jp ON jp.job_posting_id = a.job_posting_id
-            JOIN employers   e  ON e.employer_id   = jp.company_id
-            WHERE a.applicant_id = :id
-            LIMIT 1
-        ");
-        $st->execute([':id' => $applicantId]);
-        $row = $st->fetch();
-        if (!$row) return;
+        $app = Application::with(['candidate', 'jobPosting.employer'])
+            ->find($applicantId);
+        if (!$app || !$app->candidate || !$app->jobPosting) return;
 
-        $cname   = (string)$row['cand_name'];
-        $cemail  = (string)$row['cand_email'];
-        $job     = (string)$row['job_title'];
-        $company = (string)$row['company_name'];
+        $candidate = $app->candidate;
+        $job       = $app->jobPosting;
+        $employer  = $job->employer;
+
+        $cname   = (string)$candidate->full_name;
+        $cemail  = (string)$candidate->email;
+        $jobTitle = (string)$job->job_title;
+        $company  = (string)($employer->company_name ?? '');
 
         if (!$cemail) return;
 
-        $sub = "[HireMe] Your application status — {$job} @ {$company}";
+        $sub = "[HireMe] Your application status — {$jobTitle} @ {$company}";
         $msg = match (strtolower($newStatus)) {
             'interview', 'interviewing', 'call for interview' =>
-            "Good news! Your application has been moved to <strong>Interview</strong>. The employer/recruiter may contact you soon with details.",
+                "Good news! Your application has been moved to <strong>Interview</strong>. The employer/recruiter may contact you soon with details.",
             'rejected', 'declined' =>
-            "Thanks for applying. Your application status is now <strong>Rejected</strong>. Don’t be discouraged—there are more roles waiting for you!",
+                "Thanks for applying. Your application status is now <strong>Rejected</strong>. Don’t be discouraged—there are more roles waiting for you!",
             default =>
-            "Your application status is now: <strong>" . htmlspecialchars($newStatus) . "</strong>.",
+                "Your application status is now: <strong>" . htmlspecialchars($newStatus) . "</strong>.",
         };
 
-        $html = "<p>Hi {$cname},</p>
-                 <p>{$msg}</p>
-                 <p>Role: <strong>{$job}</strong><br>Company: <strong>{$company}</strong></p>";
+        $html = "<p>Hi {$cname},</p>"
+               . "<p>{$msg}</p>"
+               . "<p>Role: <strong>{$jobTitle}</strong><br>Company: <strong>{$company}</strong></p>";
         self::send($cemail, $sub, $html);
     }
 
     /** Candidate KYC verification decision from Admin. $status: 2=Approved, 1=Pending, 0=Submitted, -1=Rejected (example) */
     public static function onCandidateVerification(int $candidateId, int $status): void
     {
-        $pdo = DB::conn();
-        $st = $pdo->prepare("SELECT full_name, email FROM candidates WHERE candidate_id=:id LIMIT 1");
-        $st->execute([':id' => $candidateId]);
-        $row = $st->fetch();
-        if (!$row) return;
+        $cand = Candidate::find($candidateId);
+        if (!$cand) return;
 
-        $name  = (string)$row['full_name'];
-        $email = (string)$row['email'];
+        $name  = (string)$cand->full_name;
+        $email = (string)$cand->email;
         if (!$email) return;
 
         if ($status === 2) {
@@ -179,7 +145,6 @@ final class Notify
             $sub  = "[HireMe] Your verification could not be approved";
             $html = "<p>Hi {$name},</p><p>We’re unable to approve your verification at this time. Please re-submit with clear documents.</p>";
         } else {
-            // Usually we don’t email for pending, but you can if you want.
             $sub  = "[HireMe] Verification update";
             $html = "<p>Hi {$name},</p><p>Your verification status has been updated.</p>";
         }


### PR DESCRIPTION
## Summary
- Implement Application and Recruiter Eloquent models with relationships
- Add recruiter relations and question attachment helper to JobPosting
- Refactor JobService and Notify to use Eloquent ORM and Capsule transactions
- Update JobService tests to bootstrap ORM

## Testing
- `php tests/JobServiceTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c6e5aec8f88328b09abd0cf8630c53