### PR TITLE
Add debug flag for exception handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+APP_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# HireMe
+
+## Debugging configuration
+
+The application reads an `app.debug` flag from `config/config.php` (or the
+`APP_DEBUG` environment variable). When enabled, uncaught exceptions display the
+full message and stack trace. **Ensure deployments set `APP_DEBUG=false` in
+production** to avoid exposing sensitive information.
+

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -54,15 +54,20 @@ $config = require $root . '/config/config.php';
 // -----------------------------------------------------------------------------
 // Error handling
 // -----------------------------------------------------------------------------
-ini_set('display_errors', $config['app']['display_errors'] ?? '1');
+$debug = (bool)($config['app']['debug'] ?? false);
+ini_set('display_errors', $debug ? '1' : '0');
 error_reporting($config['app']['error_level'] ?? E_ALL);
 set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
     throw new \ErrorException($message, 0, $severity, $file, $line);
 });
-set_exception_handler(function (\Throwable $e): void {
+set_exception_handler(function (\Throwable $e) use ($debug): void {
     error_log((string) $e);
     http_response_code(500);
-    echo 'Application error';
+    if ($debug) {
+        echo $e->getMessage() . "\n" . $e->getTraceAsString();
+    } else {
+        echo 'Application error';
+    }
 });
 
 date_default_timezone_set($_ENV['APP_TZ'] ?? 'Asia/Kuala_Lumpur');

--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,8 @@
 <?php
 return [
+    'app' => [
+        'debug' => filter_var($_ENV['APP_DEBUG'] ?? true, FILTER_VALIDATE_BOOL),
+    ],
     'db' => [
         'dsn'  => 'mysql:host=127.0.0.1;dbname=hireme;charset=utf8mb4',
         'user' => 'root',


### PR DESCRIPTION
## Summary
- add `app.debug` config flag with `.env` support
- show exception message and trace when debug is enabled
- document `APP_DEBUG` usage and recommend disabling in production

## Testing
- `composer install`
- `php -l config/config.php`
- `php -l bootstrap.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ead95af48328a349a8745b912851