### PR TITLE
Add account API routes and controller

### DIFF
--- a/app/Controllers/AccountController.php
+++ b/app/Controllers/AccountController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Models\User;
+
+final class AccountController
+{
+    /**
+     * Show an account as JSON.
+     *
+     * @param array{id?:string|int} $params
+     */
+    public function apiShow(array $params): void
+    {
+        $id = isset($params['id']) ? (int)$params['id'] : 0;
+        $user = User::find($id);
+
+        header('Content-Type: application/json');
+        if (!$user) {
+            http_response_code(404);
+            echo json_encode([
+                'status'  => 'error',
+                'message' => 'Account not found',
+                'data'    => null,
+            ]);
+            return;
+        }
+
+        echo json_encode([
+            'status'  => 'success',
+            'message' => 'Account retrieved',
+            'data'    => $user->toArray(),
+        ]);
+    }
+
+    /**
+     * Create a new account from JSON request body.
+     *
+     * @param array $params
+     */
+    public function apiCreate(array $params = []): void
+    {
+        $input = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($input)) {
+            $input = [];
+        }
+
+        $email    = trim((string)($input['email'] ?? ''));
+        $password = (string)($input['password'] ?? '');
+        $role     = trim((string)($input['role'] ?? ''));
+
+        $errors = [];
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors['email'] = 'Valid email required';
+        }
+        if (strlen($password) < 8) {
+            $errors['password'] = 'Password must be at least 8 characters';
+        }
+        if ($role === '') {
+            $errors['role'] = 'Role is required';
+        }
+
+        header('Content-Type: application/json');
+        if ($errors) {
+            http_response_code(422);
+            echo json_encode([
+                'status'  => 'error',
+                'message' => 'Validation failed',
+                'data'    => $errors,
+            ]);
+            return;
+        }
+
+        $user = User::create([
+            'email'         => $email,
+            'password_hash' => password_hash($password, PASSWORD_DEFAULT),
+            'role'          => $role,
+        ]);
+
+        echo json_encode([
+            'status'  => 'success',
+            'message' => 'Account created',
+            'data'    => $user->toArray(),
+        ]);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -14,6 +14,7 @@ use App\Controllers\ApplicationController;
 use App\Controllers\PaymentController;
 use App\Controllers\RecruiterCompaniesController;
 use App\Controllers\AdminController;
+use App\Controllers\AccountController;
 
 $container = require dirname(__DIR__) . '/app/bootstrap.php';
 
@@ -188,6 +189,10 @@ $router->get('/admin/metrics',  [\App\Controllers\AdminController::class, 'overv
 $router->get('/admin/metrics/export', [\App\Controllers\AdminController::class, 'metricsExport']); // CSV
 
 $router->get('/admin/overview/export-all', [\App\Controllers\AdminController::class, 'overviewExportAll']);
+
+// API: Accounts
+$router->get('/api/accounts/{id}', [AccountController::class, 'apiShow']);
+$router->post('/api/accounts', [AccountController::class, 'apiCreate']);
 
 // Normalize path relative to BASE_URL (avoid str_starts_with for PHP 7+)
 $method  = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');


### PR DESCRIPTION
## Summary
- add AccountController with JSON APIs for showing and creating accounts
- register /api/accounts routes in public index

## Testing
- `php -l app/Controllers/AccountController.php`
- `php -l public/index.php`
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c8f227dc8328aa9c069ac2738aeb