### PR TITLE
feat: support account types for API

### DIFF
--- a/app/Controllers/AccountController.php
+++ b/app/Controllers/AccountController.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Controllers;
 
-use App\Models\User;
+use App\Models\Admin;
+use App\Models\Candidate;
+use App\Models\Employer;
+use App\Models\Recruiter;
 
 final class AccountController
 {
@@ -15,10 +18,23 @@ final class AccountController
      */
     public function apiShow(array $params): void
     {
-        $id = isset($params['id']) ? (int)$params['id'] : 0;
-        $user = User::find($id);
+        $type = isset($params['type']) ? (string) $params['type'] : (string) ($_GET['type'] ?? '');
+        $modelClass = $this->resolveModel($type);
 
         header('Content-Type: application/json');
+        if (!$modelClass) {
+            http_response_code(400);
+            echo json_encode([
+                'status'  => 'error',
+                'message' => 'type not supported',
+                'data'    => null,
+            ]);
+            return;
+        }
+
+        $id   = isset($params['id']) ? (int) $params['id'] : 0;
+        $user = $modelClass::find($id);
+
         if (!$user) {
             http_response_code(404);
             echo json_encode([
@@ -43,14 +59,28 @@ final class AccountController
      */
     public function apiCreate(array $params = []): void
     {
+        $type = isset($params['type']) ? (string) $params['type'] : (string) ($_GET['type'] ?? '');
+        $modelClass = $this->resolveModel($type);
+
+        header('Content-Type: application/json');
+        if (!$modelClass) {
+            http_response_code(400);
+            echo json_encode([
+                'status'  => 'error',
+                'message' => 'type not supported',
+                'data'    => null,
+            ]);
+            return;
+        }
+
         $input = json_decode(file_get_contents('php://input'), true);
         if (!is_array($input)) {
             $input = [];
         }
 
-        $email    = trim((string)($input['email'] ?? ''));
-        $password = (string)($input['password'] ?? '');
-        $role     = trim((string)($input['role'] ?? ''));
+        $email    = trim((string) ($input['email'] ?? ''));
+        $password = (string) ($input['password'] ?? '');
+        $role     = trim((string) ($input['role'] ?? ''));
 
         $errors = [];
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -59,11 +89,10 @@ final class AccountController
         if (strlen($password) < 8) {
             $errors['password'] = 'Password must be at least 8 characters';
         }
-        if ($role === '') {
+        if ($modelClass === Admin::class && $role === '') {
             $errors['role'] = 'Role is required';
         }
 
-        header('Content-Type: application/json');
         if ($errors) {
             http_response_code(422);
             echo json_encode([
@@ -74,16 +103,38 @@ final class AccountController
             return;
         }
 
-        $user = User::create([
+        $data = [
             'email'         => $email,
             'password_hash' => password_hash($password, PASSWORD_DEFAULT),
-            'role'          => $role,
-        ]);
+        ];
+
+        if ($modelClass === Admin::class) {
+            $data['role'] = $role;
+        }
+
+        $user = $modelClass::create($data);
 
         echo json_encode([
             'status'  => 'success',
             'message' => 'Account created',
             'data'    => $user->toArray(),
         ]);
+    }
+
+    /**
+     * Resolve the model class for a given account type.
+     */
+    private function resolveModel(string $type): ?string
+    {
+        $map = [
+            'admin'     => Admin::class,
+            'candidate' => Candidate::class,
+            'employer'  => Employer::class,
+            'recruiter' => Recruiter::class,
+        ];
+
+        $key = strtolower(trim($type));
+
+        return $map[$key] ?? null;
     }
 }

--- a/docs/ifa.md
+++ b/docs/ifa.md
@@ -1,12 +1,13 @@
 # REST API Endpoints
 
-## GET /api/accounts/{id}
+## GET /api/accounts/{type}/{id}
 - **Function**: `AccountController::apiShow`
-- **Description**: Retrieve account details by ID.
+- **Description**: Retrieve account details by ID for a given account type.
 
 ### Request Parameters
 | Parameter | Type | Mandatory | Description |
 |-----------|------|-----------|-------------|
+| `type` | string (path) | Yes | Account type (`admin`, `candidate`, `employer`, `recruiter`) |
 | `id` | integer (path) | Yes | Account identifier |
 
 ### Response Fields
@@ -23,29 +24,26 @@
   "message": "Account retrieved",
   "data": {
     "id": 123,
-    "email": "user@example.com",
-    "role": "Candidate"
+    "email": "user@example.com"
   }
 }
 ```
 
-## POST /api/accounts
+## POST /api/accounts/{type}
 - **Function**: `AccountController::apiCreate`
-- **Description**: Create a new account.
+- **Description**: Create a new account for a given type.
 
 ### Request Body
 | Field | Type | Mandatory | Description |
 |-------|------|-----------|-------------|
 | `email` | string | Yes | Valid email address |
 | `password` | string | Yes | Minimum 8 characters |
-| `role` | string | Yes | User role (e.g. `Candidate`, `Employer`) |
 
 ### Example Request
 ```json
 {
   "email": "new@example.com",
-  "password": "secret123",
-  "role": "Employer"
+  "password": "secret123"
 }
 ```
 
@@ -63,8 +61,7 @@
   "message": "Account created",
   "data": {
     "id": 124,
-    "email": "new@example.com",
-    "role": "Employer"
+    "email": "new@example.com"
   }
 }
 ```

--- a/public/index.php
+++ b/public/index.php
@@ -191,8 +191,8 @@ $router->get('/admin/metrics/export', [\App\Controllers\AdminController::class, 
 $router->get('/admin/overview/export-all', [\App\Controllers\AdminController::class, 'overviewExportAll']);
 
 // API: Accounts
-$router->get('/api/accounts/{id}', [AccountController::class, 'apiShow']);
-$router->post('/api/accounts', [AccountController::class, 'apiCreate']);
+$router->get('/api/accounts/{type}/{id}', [AccountController::class, 'apiShow']);
+$router->post('/api/accounts/{type}', [AccountController::class, 'apiCreate']);
 
 // Normalize path relative to BASE_URL (avoid str_starts_with for PHP 7+)
 $method  = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');


### PR DESCRIPTION
## Summary
- handle account type in AccountController and resolve appropriate model
- expose new routes with type parameter for account APIs
- document account endpoints with type-aware paths

## Testing
- `php tests/JobServiceTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7d81cb96c8328bf74befcd34b8376