### PR TITLE
Implement resume generation and harden ORM routing utilities

### DIFF
--- a/app/Controllers/Api/AccountsController.php
+++ b/app/Controllers/Api/AccountsController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Controllers\Api;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Repositories\CandidateRepository;
+use App\Repositories\EmployerRepository;
+use App\Repositories\RecruiterRepository;
+use App\Services\AccountService;
+use App\Services\Auth\AuthService;
+
+class AccountsController extends ApiController
+{
+    public function __construct(
+        AuthService $auth,
+        private AccountService $accounts,
+        private CandidateRepository $candidates,
+        private EmployerRepository $employers,
+        private RecruiterRepository $recruiters
+    ) {
+        parent::__construct($auth);
+    }
+
+    public function index(Request $request, string $type): Response
+    {
+        $repositories = [
+            'candidates' => $this->candidates,
+            'employers' => $this->employers,
+            'recruiters' => $this->recruiters,
+        ];
+
+        if (!isset($repositories[$type])) {
+            return $this->error('Unsupported account type.', 404);
+        }
+
+        $perPage = max(1, (int) $request->query('per_page', 25));
+        $page = max(1, (int) $request->query('page', 1));
+        $paginator = $repositories[$type]->query()->paginate($perPage, $page);
+
+        $items = array_map(static function ($item) {
+            if (is_object($item) && method_exists($item, 'toArray')) {
+                return $item->toArray();
+            }
+
+            return (array) $item;
+        }, $paginator['data']);
+
+        return $this->success($items, 200, $paginator['meta']);
+    }
+
+    public function store(Request $request, string $type): Response
+    {
+        return match ($type) {
+            'candidates' => $this->success(['user' => $this->accounts->registerCandidate($request->all())->toArray()], 201),
+            'employers' => $this->success(['user' => $this->accounts->registerEmployer($request->all())->toArray()], 201),
+            'recruiters' => $this->success(['user' => $this->accounts->registerRecruiter($request->all())->toArray()], 201),
+            default => $this->error('Unsupported account type.', 404),
+        };
+    }
+}

--- a/app/Controllers/Api/ApiController.php
+++ b/app/Controllers/Api/ApiController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Controllers\Api;
+
+use App\Core\Controller;
+use App\Core\Request;
+use App\Core\Response;
+use App\Models\User;
+use App\Services\Auth\AuthService;
+
+abstract class ApiController extends Controller
+{
+    public function __construct(protected ?AuthService $auth = null)
+    {
+    }
+
+    protected function success(array $data = [], int $status = 200, array $meta = []): Response
+    {
+        $payload = ['data' => $data];
+        if (!empty($meta)) {
+            $payload['meta'] = $meta;
+        }
+
+        return Response::json($payload, $status);
+    }
+
+    protected function error(string $message, int $status = 400, array $meta = []): Response
+    {
+        return Response::json(['errors' => [['detail' => $message, 'meta' => $meta]]], $status);
+    }
+
+    protected function userFromToken(Request $request): ?User
+    {
+        if (!$this->auth) {
+            return null;
+        }
+
+        $token = $request->bearerToken();
+        return $this->auth->userByToken($token);
+    }
+}

--- a/app/Core/Bootstrap/Bootstrap.php
+++ b/app/Core/Bootstrap/Bootstrap.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Core\Bootstrap;
+
+use App\Core\Application;
+use App\Core\Container;
+use App\Core\ErrorHandler;
+use App\Core\Router;
+use App\Core\Session;
+use App\Core\Support\Config;
+use App\Core\Support\Logger;
+use App\Core\ORM\ConnectionManager;
+use App\Core\ORM\EntityManager;
+use App\Services\Auth\AuthService;
+use App\Services\Mail\MailService;
+use App\Services\Notifications\NotificationService;
+use App\Services\Payments\PaymentGateway;
+use Dotenv\Dotenv;
+
+class Bootstrap
+{
+    public function boot(): Application
+    {
+        $this->loadEnv();
+        $this->bootstrapConfig();
+
+        $container = $this->buildContainer();
+        $container->make(EntityManager::class);
+        $router = new Router();
+        $errorHandler = new ErrorHandler((bool) config('app.debug', false));
+
+        $application = new Application($container, $router, $errorHandler);
+
+        $container->instance(Application::class, $application);
+        $container->instance(Router::class, $router);
+        $container->instance(ErrorHandler::class, $errorHandler);
+
+        $this->registerRoutes($router, $container);
+
+        return $application;
+    }
+
+    private function loadEnv(): void
+    {
+        if (file_exists(base_path('.env'))) {
+            Dotenv::createImmutable(base_path())->safeLoad();
+        }
+    }
+
+    private function bootstrapConfig(): void
+    {
+        $config = Config::instance();
+        $config->loadFromDirectory(config_path());
+        date_default_timezone_set($config->get('app.timezone', 'UTC'));
+    }
+
+    private function buildContainer(): Container
+    {
+        $container = new Container();
+
+        $container->singleton(Session::class, fn () => new Session());
+
+        $container->singleton(ConnectionManager::class, function () {
+            return new ConnectionManager(config('database'));
+        });
+
+        $container->singleton(EntityManager::class, function (Container $container) {
+            return new EntityManager($container->make(ConnectionManager::class));
+        });
+
+        $container->singleton(\PDO::class, function (Container $container) {
+            return $container->make(ConnectionManager::class)->connection();
+        });
+
+        $container->singleton(Logger::class, function () {
+            return new Logger(storage_path('logs/app.log'));
+        });
+
+        $container->singleton(MailService::class, function (Container $container) {
+            return new MailService(config('mail'), $container->make(Logger::class));
+        });
+
+        $container->singleton(NotificationService::class, function (Container $container) {
+            return new NotificationService($container->make(Logger::class));
+        });
+
+        $container->singleton(PaymentGateway::class, function (Container $container) {
+            return new PaymentGateway(config('services.stripe'), $container->make(Logger::class));
+        });
+
+        $container->singleton(AuthService::class, function (Container $container) {
+            return new AuthService($container->make(EntityManager::class), $container->make(Session::class));
+        });
+
+        return $container;
+    }
+
+    private function registerRoutes(Router $router, Container $container): void
+    {
+        require base_path('routes/web.php');
+        require base_path('routes/api.php');
+    }
+}

--- a/app/Core/Database/MigrationException.php
+++ b/app/Core/Database/MigrationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Core\Database;
+
+use RuntimeException;
+use Throwable;
+
+class MigrationException extends RuntimeException
+{
+    public function __construct(string $message, private string $migrationFile, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function migrationFile(): string
+    {
+        return $this->migrationFile;
+    }
+}

--- a/app/Core/Database/Migrator.php
+++ b/app/Core/Database/Migrator.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Core\Database;
+
+use App\Core\ORM\ConnectionManager;
+use PDO;
+use Throwable;
+
+class Migrator
+{
+    public function __construct(private ConnectionManager $connections, private string $path)
+    {
+    }
+
+    public function migrate(): void
+    {
+        $pdo = $this->connections->connection();
+        $this->ensureMigrationsTable($pdo);
+        $files = $this->migrationFiles();
+        $batch = $this->currentBatch($pdo) + 1;
+
+        foreach ($files as $file) {
+            $name = basename($file, '.php');
+            if ($this->hasRun($pdo, $name)) {
+                continue;
+            }
+
+            $migration = $this->resolve($file);
+            $pdo->beginTransaction();
+            try {
+                $migration->up($pdo);
+                $this->logMigration($pdo, $name, $batch);
+                $pdo->commit();
+            } catch (Throwable $e) {
+                $pdo->rollBack();
+                throw new MigrationException(
+                    sprintf('Failed to run migration %s: %s', $name, $e->getMessage()),
+                    $file,
+                    $e
+                );
+            }
+        }
+    }
+
+    public function rollback(): void
+    {
+        $pdo = $this->connections->connection();
+        $this->ensureMigrationsTable($pdo);
+        $batch = $this->currentBatch($pdo);
+        if ($batch === 0) {
+            return;
+        }
+
+        $statement = $pdo->prepare('SELECT migration FROM migrations WHERE batch = ? ORDER BY id DESC');
+        $statement->execute([$batch]);
+        $migrations = $statement->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach ($migrations as $migrationName) {
+            $file = $this->path . DIRECTORY_SEPARATOR . $migrationName . '.php';
+            if (!file_exists($file)) {
+                continue;
+            }
+
+            $migration = $this->resolve($file);
+            $pdo->beginTransaction();
+            try {
+                $migration->down($pdo);
+                $pdo->prepare('DELETE FROM migrations WHERE migration = ?')->execute([$migrationName]);
+                $pdo->commit();
+            } catch (Throwable $e) {
+                $pdo->rollBack();
+                throw new MigrationException(
+                    sprintf('Failed to rollback migration %s: %s', $migrationName, $e->getMessage()),
+                    $file,
+                    $e
+                );
+            }
+        }
+    }
+
+    private function resolve(string $file): Migration
+    {
+        $migration = require $file;
+        if (!$migration instanceof Migration) {
+            throw new \RuntimeException(sprintf('Migration %s must return an instance of %s.', $file, Migration::class));
+        }
+
+        return $migration;
+    }
+
+    private function ensureMigrationsTable(PDO $pdo): void
+    {
+        $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+
+        if ($driver === 'mysql') {
+            $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (
+                id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                migration VARCHAR(255) NOT NULL,
+                batch INT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+            return;
+        }
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS migrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            migration VARCHAR(255) NOT NULL,
+            batch INTEGER NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    private function migrationFiles(): array
+    {
+        $files = glob(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.php');
+        sort($files);
+        return $files;
+    }
+
+    private function hasRun(PDO $pdo, string $migration): bool
+    {
+        $statement = $pdo->prepare('SELECT COUNT(*) FROM migrations WHERE migration = ?');
+        $statement->execute([$migration]);
+        return (int) $statement->fetchColumn() > 0;
+    }
+
+    private function logMigration(PDO $pdo, string $migration, int $batch): void
+    {
+        $statement = $pdo->prepare('INSERT INTO migrations (migration, batch) VALUES (?, ?)');
+        $statement->execute([$migration, $batch]);
+    }
+
+    private function currentBatch(PDO $pdo): int
+    {
+        $statement = $pdo->query('SELECT MAX(batch) FROM migrations');
+        $value = $statement->fetchColumn();
+        return (int) $value;
+    }
+}

--- a/app/Core/Database/SeederException.php
+++ b/app/Core/Database/SeederException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Core\Database;
+
+use RuntimeException;
+use Throwable;
+
+class SeederException extends RuntimeException
+{
+    public function __construct(string $message, private string $seederFile, ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function seederFile(): string
+    {
+        return $this->seederFile;
+    }
+}

--- a/app/Core/Database/SeederRunner.php
+++ b/app/Core/Database/SeederRunner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Core\Database;
+
+use App\Core\ORM\ConnectionManager;
+use PDO;
+use Throwable;
+
+class SeederRunner
+{
+    public function __construct(private ConnectionManager $connections, private string $path)
+    {
+    }
+
+    public function seed(): void
+    {
+        $pdo = $this->connections->connection();
+        foreach ($this->seeders() as $file) {
+            $seeder = require $file;
+            if (!$seeder instanceof Seeder) {
+                throw new \RuntimeException(sprintf('Seeder %s must return an instance of %s.', $file, Seeder::class));
+            }
+
+            $startedTransaction = false;
+            if (!$pdo->inTransaction()) {
+                $pdo->beginTransaction();
+                $startedTransaction = true;
+            }
+
+            try {
+                $seeder->run($pdo);
+                if ($startedTransaction && $pdo->inTransaction()) {
+                    $pdo->commit();
+                }
+            } catch (Throwable $exception) {
+                if ($startedTransaction && $pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+
+                throw new SeederException(
+                    sprintf('Failed to run seeder %s: %s', basename($file), $exception->getMessage()),
+                    $file,
+                    $exception
+                );
+            }
+        }
+    }
+
+    private function seeders(): array
+    {
+        $files = glob(rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.php');
+        sort($files);
+        return $files;
+    }
+}

--- a/app/Core/ORM/Model.php
+++ b/app/Core/ORM/Model.php
@@ -1,0 +1,407 @@
+<?php
+
+namespace App\Core\ORM;
+
+use App\Core\ORM\Relations\BelongsTo;
+use App\Core\ORM\Relations\BelongsToMany;
+use App\Core\ORM\Relations\HasMany;
+use App\Core\ORM\Relations\HasOne;
+use App\Core\ORM\Relations\Relation;
+use JsonException;
+use JsonSerializable;
+use RuntimeException;
+
+abstract class Model implements JsonSerializable
+{
+    protected static ?EntityManager $entityManager = null;
+
+    protected string $table;
+
+    protected string $primaryKey = 'id';
+
+    protected array $fillable = [];
+
+    protected array $hidden = [];
+
+    protected array $casts = [];
+
+    protected bool $timestamps = true;
+
+    protected string $createdAtColumn = 'created_at';
+
+    protected string $updatedAtColumn = 'updated_at';
+
+    protected array $attributes = [];
+
+    protected array $original = [];
+
+    protected array $relations = [];
+
+    protected bool $exists = false;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->fill($attributes);
+    }
+
+    public static function setEntityManager(EntityManager $entityManager): void
+    {
+        static::$entityManager = $entityManager;
+    }
+
+    public static function entityManager(): EntityManager
+    {
+        if (!static::$entityManager) {
+            throw new RuntimeException('Entity manager has not been set.');
+        }
+
+        return static::$entityManager;
+    }
+
+    public static function query(): QueryBuilder
+    {
+        $instance = new static();
+        return static::entityManager()->query($instance->getTable(), static::class);
+    }
+
+    public static function all(): array
+    {
+        return static::query()->get();
+    }
+
+    public static function find(mixed $id): ?static
+    {
+        return static::query()->find($id);
+    }
+
+    public static function create(array $attributes): static
+    {
+        $model = new static($attributes);
+        $model->save();
+        return $model;
+    }
+
+    public function newQuery(): QueryBuilder
+    {
+        return static::query();
+    }
+
+    public function fill(array $attributes): static
+    {
+        foreach ($attributes as $key => $value) {
+            if ($this->isFillable($key)) {
+                $this->setAttribute($key, $value);
+            }
+        }
+
+        return $this;
+    }
+
+    public function forceFill(array $attributes): static
+    {
+        foreach ($attributes as $key => $value) {
+            $this->attributes[$key] = $this->castAttribute($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function getTable(): string
+    {
+        if (!isset($this->table)) {
+            $class = (new \ReflectionClass(static::class))->getShortName();
+            $this->table = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $class)) . 's';
+        }
+
+        return $this->table;
+    }
+
+    public function getKey(): mixed
+    {
+        return $this->getAttribute($this->primaryKey);
+    }
+
+    public function getKeyName(): string
+    {
+        return $this->primaryKey;
+    }
+
+    public static function keyName(): string
+    {
+        $defaults = (new \ReflectionClass(static::class))->getDefaultProperties();
+        if (isset($defaults['primaryKey']) && is_string($defaults['primaryKey'])) {
+            return $defaults['primaryKey'];
+        }
+
+        $instance = new static();
+
+        return $instance->getKeyName();
+    }
+
+    public function getAttribute(string $key): mixed
+    {
+        if (array_key_exists($key, $this->attributes)) {
+            return $this->attributes[$key];
+        }
+
+        if ($this->relationLoaded($key)) {
+            return $this->relations[$key];
+        }
+
+        if (method_exists($this, $key)) {
+            return $this->getRelationship($key);
+        }
+
+        return null;
+    }
+
+    public function setAttribute(string $key, mixed $value): void
+    {
+        $this->attributes[$key] = $this->castAttribute($key, $value);
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function toArray(): array
+    {
+        $attributes = array_diff_key($this->attributes, array_flip($this->hidden));
+
+        foreach ($this->relations as $name => $relation) {
+            if (in_array($name, $this->hidden, true)) {
+                continue;
+            }
+
+            if ($relation instanceof JsonSerializable) {
+                $attributes[$name] = $relation->jsonSerialize();
+            } elseif (is_array($relation)) {
+                $attributes[$name] = array_map(static fn ($item) => $item instanceof JsonSerializable ? $item->jsonSerialize() : $item, $relation);
+            } else {
+                $attributes[$name] = $relation;
+            }
+        }
+
+        foreach ($attributes as $key => $value) {
+            $attributes[$key] = $this->prepareValueForDatabase($key, $value);
+        }
+
+        return $attributes;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function __get(string $name): mixed
+    {
+        return $this->getAttribute($name);
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->setAttribute($name, $value);
+    }
+
+    public function save(): bool
+    {
+        $entityManager = static::entityManager();
+        $query = $entityManager->query($this->getTable(), static::class);
+        $attributes = $this->prepareAttributesForPersistence();
+
+        if ($this->exists) {
+            $updated = $query->where($this->primaryKey, '=', $this->getKey())->update($attributes);
+            if ($updated) {
+                $this->syncOriginal();
+            }
+            return (bool) $updated;
+        }
+
+        $id = $query->insertGetId($attributes);
+        if ($id) {
+            $this->setAttribute($this->primaryKey, $id);
+            $this->exists = true;
+            $this->syncOriginal();
+            return true;
+        }
+
+        return false;
+    }
+
+    public function delete(): bool
+    {
+        if (!$this->exists) {
+            return false;
+        }
+
+        $deleted = $this->newQuery()->where($this->primaryKey, '=', $this->getKey())->delete();
+        if ($deleted) {
+            $this->exists = false;
+        }
+
+        return (bool) $deleted;
+    }
+
+    public function wasChanged(?string $attribute = null): bool
+    {
+        $changes = array_diff_assoc($this->attributes, $this->original);
+        if ($attribute === null) {
+            return !empty($changes);
+        }
+
+        return array_key_exists($attribute, $changes);
+    }
+
+    public function syncOriginal(): void
+    {
+        $this->original = $this->attributes;
+    }
+
+    public function load(array|string $relations): static
+    {
+        foreach ((array) $relations as $relation) {
+            $this->relations[$relation] = $this->getRelationship($relation);
+        }
+
+        return $this;
+    }
+
+    public function setRelation(string $relation, mixed $value): void
+    {
+        $this->relations[$relation] = $value;
+    }
+
+    public function getRelation(string $relation): mixed
+    {
+        return $this->relations[$relation] ?? null;
+    }
+
+    public function relationLoaded(string $relation): bool
+    {
+        return array_key_exists($relation, $this->relations);
+    }
+
+    protected function prepareAttributesForPersistence(): array
+    {
+        $attributes = $this->getFillableAttributes();
+
+        if ($this->timestamps) {
+            $now = now();
+            if (!$this->exists && !isset($attributes[$this->createdAtColumn])) {
+                $attributes[$this->createdAtColumn] = $now;
+                $this->attributes[$this->createdAtColumn] = $now;
+            }
+            $attributes[$this->updatedAtColumn] = $now;
+            $this->attributes[$this->updatedAtColumn] = $now;
+        }
+
+        return $attributes;
+    }
+
+    protected function getFillableAttributes(): array
+    {
+        if (empty($this->fillable)) {
+            return $this->attributes;
+        }
+
+        return array_intersect_key($this->attributes, array_flip($this->fillable));
+    }
+
+    protected function isFillable(string $key): bool
+    {
+        return empty($this->fillable) || in_array($key, $this->fillable, true);
+    }
+
+    protected function castAttribute(string $key, mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $cast = $this->casts[$key] ?? null;
+        return match ($cast) {
+            'int', 'integer' => (int) $value,
+            'float', 'double' => (float) $value,
+            'bool', 'boolean' => (bool) $value,
+            'datetime' => is_string($value) ? new \DateTimeImmutable($value) : $value,
+            'array', 'json' => is_string($value) ? json_decode($value, true) : (array) $value,
+            default => $value,
+        };
+    }
+
+    protected function prepareValueForDatabase(string $key, mixed $value): mixed
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s');
+        }
+
+        $cast = $this->casts[$key] ?? null;
+
+        return match ($cast) {
+            'datetime' => $value instanceof \DateTimeInterface
+                ? $value->format('Y-m-d H:i:s')
+                : (is_string($value) ? $value : null),
+            'array', 'json' => $this->encodeJson($value),
+            'bool', 'boolean' => $value ? 1 : 0,
+            default => $value,
+        };
+    }
+
+    private function encodeJson(mixed $value): string
+    {
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Unable to encode attribute to JSON.', 0, $exception);
+        }
+    }
+
+    protected function getRelationship(string $name): mixed
+    {
+        if ($this->relationLoaded($name)) {
+            return $this->relations[$name];
+        }
+
+        if (!method_exists($this, $name)) {
+            throw new RuntimeException(sprintf('Relationship method "%s" does not exist on %s.', $name, static::class));
+        }
+
+        $relation = $this->{$name}();
+        if ($relation instanceof Relation) {
+            $results = $relation->getResults();
+        } else {
+            $results = $relation;
+        }
+
+        $this->setRelation($name, $results);
+
+        return $results;
+    }
+
+    protected function hasMany(string $related, string $foreignKey, string $localKey = 'id'): HasMany
+    {
+        return new HasMany($this, $related, $foreignKey, $localKey);
+    }
+
+    protected function hasOne(string $related, string $foreignKey, string $localKey = 'id'): HasOne
+    {
+        return new HasOne($this, $related, $foreignKey, $localKey);
+    }
+
+    protected function belongsTo(string $related, string $foreignKey, string $ownerKey = 'id'): BelongsTo
+    {
+        return new BelongsTo($this, $related, $foreignKey, $ownerKey);
+    }
+
+    protected function belongsToMany(string $related, string $pivotTable, string $foreignPivotKey, string $relatedPivotKey, string $parentKey = 'id', string $relatedKey = 'id'): BelongsToMany
+    {
+        return new BelongsToMany($this, $related, $pivotTable, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey);
+    }
+
+    public function setExists(bool $exists): void
+    {
+        $this->exists = $exists;
+    }
+}

--- a/app/Core/ORM/QueryBuilder.php
+++ b/app/Core/ORM/QueryBuilder.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace App\Core\ORM;
+
+use JsonException;
+use PDO;
+use PDOStatement;
+use RuntimeException;
+
+class QueryBuilder
+{
+    private array $selects = ['*'];
+    private array $wheres = [];
+    private array $joins = [];
+    private array $orders = [];
+    private ?int $limit = null;
+    private ?int $offset = null;
+    private array $with = [];
+
+    /** @var array<string, array<int, mixed>> */
+    private array $bindings = ['where' => []];
+
+    public function __construct(private PDO $pdo, private string $table, private ?string $modelClass = null)
+    {
+    }
+
+    public function select(string|array $columns): self
+    {
+        $this->selects = is_array($columns) ? $columns : func_get_args();
+        return $this;
+    }
+
+    public function where($column, $operator = null, $value = null, string $boolean = 'AND'): self
+    {
+        if ($column instanceof \Closure) {
+            $query = new self($this->pdo, $this->table, $this->modelClass);
+            $column($query);
+            $this->wheres[] = ['type' => 'nested', 'query' => $query, 'boolean' => $boolean];
+            $this->addBindings($query->getBindings()['where']);
+            return $this;
+        }
+
+        if (is_array($column)) {
+            foreach ($column as $key => $val) {
+                $this->where($key, '=', $val, $boolean);
+            }
+            return $this;
+        }
+
+        if ($value === null) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        $this->wheres[] = ['type' => 'basic', 'column' => $column, 'operator' => $operator, 'boolean' => $boolean];
+        $this->addBinding($value);
+
+        return $this;
+    }
+
+    public function orWhere($column, $operator = null, $value = null): self
+    {
+        return $this->where($column, $operator, $value, 'OR');
+    }
+
+    public function whereIn(string $column, array $values, string $boolean = 'AND', bool $not = false): self
+    {
+        $this->wheres[] = ['type' => 'in', 'column' => $column, 'values' => $values, 'boolean' => $boolean, 'not' => $not];
+        foreach ($values as $value) {
+            $this->addBinding($value);
+        }
+        return $this;
+    }
+
+    public function whereNull(string $column, string $boolean = 'AND', bool $not = false): self
+    {
+        $this->wheres[] = ['type' => 'null', 'column' => $column, 'boolean' => $boolean, 'not' => $not];
+        return $this;
+    }
+
+    public function join(string $table, string $first, string $operator, string $second, string $type = 'INNER'): self
+    {
+        $this->joins[] = compact('type', 'table', 'first', 'operator', 'second');
+        return $this;
+    }
+
+    public function orderBy(string $column, string $direction = 'ASC'): self
+    {
+        $this->orders[] = [$column, strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC'];
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    public function offset(int $offset): self
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    public function with(array|string $relations): self
+    {
+        $this->with = array_merge($this->with, (array) $relations);
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $sql = $this->compileSelect();
+        $statement = $this->execute($sql, $this->prepareBindings());
+        $results = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        return $this->hydrate($results);
+    }
+
+    public function first(): mixed
+    {
+        $this->limit(1);
+        $results = $this->get();
+        return $results[0] ?? null;
+    }
+
+    public function find(mixed $id): mixed
+    {
+        return $this->where($this->primaryKey(), '=', $id)->first();
+    }
+
+    public function create(array $attributes): mixed
+    {
+        if ($this->modelClass) {
+            /** @var Model $model */
+            $model = new $this->modelClass($attributes);
+            $model->save();
+            return $model;
+        }
+
+        $this->insert($attributes);
+        return $attributes;
+    }
+
+    public function insert(array $attributes): bool
+    {
+        $columns = array_keys($attributes);
+        $placeholders = implode(', ', array_fill(0, count($columns), '?'));
+        $sql = sprintf('INSERT INTO %s (%s) VALUES (%s)', $this->table, implode(', ', $columns), $placeholders);
+        $statement = $this->execute($sql, array_values($attributes));
+        return $statement->rowCount() > 0;
+    }
+
+    public function insertGetId(array $attributes): int
+    {
+        $this->insert($attributes);
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function update(array $attributes): int
+    {
+        if (empty($this->wheres)) {
+            throw new RuntimeException('Update statements must have a where clause.');
+        }
+
+        $sets = implode(', ', array_map(static fn ($column) => sprintf('%s = ?', $column), array_keys($attributes)));
+        $sql = sprintf('UPDATE %s SET %s %s', $this->table, $sets, $this->compileWhere());
+        $bindings = array_merge(array_values($attributes), $this->prepareBindings());
+        $statement = $this->execute($sql, $bindings);
+        return $statement->rowCount();
+    }
+
+    public function delete(): int
+    {
+        if (empty($this->wheres)) {
+            throw new RuntimeException('Delete statements must have a where clause.');
+        }
+
+        $sql = sprintf('DELETE FROM %s %s', $this->table, $this->compileWhere());
+        $statement = $this->execute($sql, $this->prepareBindings());
+        return $statement->rowCount();
+    }
+
+    public function count(): int
+    {
+        $clone = clone $this;
+        $clone->orders = [];
+        $clone->limit = null;
+        $clone->offset = null;
+        $sql = sprintf('SELECT COUNT(*) as aggregate FROM (%s) as sub', $clone->compileSelect());
+        $statement = $clone->execute($sql, $clone->prepareBindings());
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+        return (int) ($result['aggregate'] ?? 0);
+    }
+
+    public function paginate(int $perPage = 15, int $page = 1): array
+    {
+        $total = $this->count();
+        $this->limit($perPage)->offset(($page - 1) * $perPage);
+        $items = $this->get();
+
+        return [
+            'data' => $items,
+            'meta' => [
+                'total' => $total,
+                'per_page' => $perPage,
+                'current_page' => $page,
+                'last_page' => $perPage === 0 ? 1 : (int) max(1, ceil($total / $perPage)),
+            ],
+        ];
+    }
+
+    private function primaryKey(): string
+    {
+        if ($this->modelClass) {
+            /** @var class-string<Model> $model */
+            $model = $this->modelClass;
+            return $model::keyName();
+        }
+
+        return 'id';
+    }
+
+    private function compileSelect(): string
+    {
+        $columns = implode(', ', $this->selects);
+        $sql = sprintf('SELECT %s FROM %s', $columns, $this->table);
+
+        if (!empty($this->joins)) {
+            foreach ($this->joins as $join) {
+                $sql .= sprintf(' %s JOIN %s ON %s %s %s', $join['type'], $join['table'], $join['first'], $join['operator'], $join['second']);
+            }
+        }
+
+        $sql .= $this->compileWhere();
+
+        if (!empty($this->orders)) {
+            $orderClauses = array_map(static fn ($order) => sprintf('%s %s', $order[0], $order[1]), $this->orders);
+            $sql .= ' ORDER BY ' . implode(', ', $orderClauses);
+        }
+
+        if ($this->limit !== null) {
+            $sql .= ' LIMIT ' . $this->limit;
+        }
+
+        if ($this->offset !== null) {
+            $sql .= ' OFFSET ' . $this->offset;
+        }
+
+        return $sql;
+    }
+
+    private function compileWhere(): string
+    {
+        if (empty($this->wheres)) {
+            return '';
+        }
+
+        $segments = [];
+        foreach ($this->wheres as $index => $where) {
+            $prefix = $index === 0 ? 'WHERE' : $where['boolean'];
+
+            $segments[] = match ($where['type']) {
+                'basic' => sprintf('%s %s %s ?', $prefix, $where['column'], $where['operator']),
+                'in' => sprintf('%s %s %sIN (%s)', $prefix, $where['column'], $where['not'] ? 'NOT ' : '', implode(', ', array_fill(0, count($where['values']), '?'))),
+                'null' => sprintf('%s %s IS %sNULL', $prefix, $where['column'], $where['not'] ? 'NOT ' : ''),
+                'nested' => sprintf('%s (%s)', $prefix, preg_replace('/^WHERE\s+/i', '', trim($where['query']->compileWhere()))),
+                default => '',
+            };
+        }
+
+        return ' ' . implode(' ', array_filter($segments));
+    }
+
+    private function hydrate(array $results): array
+    {
+        if ($this->modelClass === null) {
+            return $results;
+        }
+
+        $models = [];
+        foreach ($results as $row) {
+            /** @var Model $model */
+            $model = new $this->modelClass();
+            $model->forceFill($row);
+            $model->syncOriginal();
+            $model->setExists(true);
+            $models[] = $model;
+        }
+
+        if (!empty($this->with)) {
+            foreach ($models as $model) {
+                $model->load($this->with);
+            }
+        }
+
+        return $models;
+    }
+
+    private function prepareBindings(): array
+    {
+        $filtered = array_filter($this->bindings);
+        if (empty($filtered)) {
+            return [];
+        }
+
+        return array_merge(...array_values($filtered));
+    }
+
+    private function addBinding(mixed $value, string $type = 'where'): void
+    {
+        $this->bindings[$type][] = $value;
+    }
+
+    private function addBindings(array $values, string $type = 'where'): void
+    {
+        foreach ($values as $value) {
+            $this->addBinding($value, $type);
+        }
+    }
+
+    private function getBindings(): array
+    {
+        return $this->bindings;
+    }
+
+    private function execute(string $sql, array $bindings): PDOStatement
+    {
+        $prepared = array_map(function ($binding) {
+            if ($binding instanceof \DateTimeInterface) {
+                return $binding->format('Y-m-d H:i:s');
+            }
+
+            if (is_array($binding)) {
+                try {
+                    return json_encode($binding, JSON_THROW_ON_ERROR);
+                } catch (JsonException $exception) {
+                    throw new RuntimeException('Unable to encode binding to JSON.', 0, $exception);
+                }
+            }
+
+            return $binding;
+        }, $bindings);
+
+        $statement = $this->pdo->prepare($sql);
+        $statement->execute($prepared);
+        return $statement;
+    }
+}

--- a/app/Core/ORM/Relations/BelongsTo.php
+++ b/app/Core/ORM/Relations/BelongsTo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Core\ORM\Relations;
+
+use App\Core\ORM\Model;
+
+class BelongsTo extends Relation
+{
+    public function __construct(Model $parent, string $related, string $foreignKey, string $ownerKey)
+    {
+        $relatedInstance = new $related();
+        $query = $related::query()->where($ownerKey, '=', $parent->getAttribute($foreignKey));
+        parent::__construct($parent, $query);
+    }
+
+    protected function resolve(): ?Model
+    {
+        return $this->query->first();
+    }
+}

--- a/app/Core/ORM/Relations/BelongsToMany.php
+++ b/app/Core/ORM/Relations/BelongsToMany.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Core\ORM\Relations;
+
+use App\Core\ORM\Model;
+use App\Core\ORM\QueryBuilder;
+
+class BelongsToMany extends Relation
+{
+    private string $pivotTable;
+    private string $foreignPivotKey;
+    private string $relatedPivotKey;
+    private string $parentKey;
+    private string $relatedKey;
+
+    public function __construct(
+        Model $parent,
+        string $related,
+        string $pivotTable,
+        string $foreignPivotKey,
+        string $relatedPivotKey,
+        string $parentKey,
+        string $relatedKey
+    ) {
+        $this->pivotTable = $pivotTable;
+        $this->foreignPivotKey = $foreignPivotKey;
+        $this->relatedPivotKey = $relatedPivotKey;
+        $this->parentKey = $parentKey;
+        $this->relatedKey = $relatedKey;
+
+        $relatedInstance = new $related();
+        $query = $related::query()->join(
+            $pivotTable,
+            sprintf('%s.%s', $relatedInstance->getTable(), $relatedKey),
+            '=',
+            sprintf('%s.%s', $pivotTable, $relatedPivotKey)
+        )->where(sprintf('%s.%s', $pivotTable, $foreignPivotKey), '=', $parent->getAttribute($parentKey));
+
+        parent::__construct($parent, $query);
+    }
+
+    protected function resolve(): array
+    {
+        return $this->query->get();
+    }
+}

--- a/app/Core/ORM/Relations/HasMany.php
+++ b/app/Core/ORM/Relations/HasMany.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Core\ORM\Relations;
+
+use App\Core\ORM\Model;
+
+class HasMany extends Relation
+{
+    public function __construct(Model $parent, string $related, string $foreignKey, string $localKey)
+    {
+        $instance = new $related();
+        $query = $related::query()->where($foreignKey, '=', $parent->getAttribute($localKey));
+        parent::__construct($parent, $query);
+    }
+
+    protected function resolve(): array
+    {
+        return $this->query->get();
+    }
+}

--- a/app/Core/ORM/Relations/HasOne.php
+++ b/app/Core/ORM/Relations/HasOne.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Core\ORM\Relations;
+
+use App\Core\ORM\Model;
+
+class HasOne extends Relation
+{
+    public function __construct(Model $parent, string $related, string $foreignKey, string $localKey)
+    {
+        $query = $related::query()->where($foreignKey, '=', $parent->getAttribute($localKey));
+        parent::__construct($parent, $query);
+    }
+
+    protected function resolve(): ?Model
+    {
+        return $this->query->first();
+    }
+}

--- a/app/Core/ORM/Relations/Relation.php
+++ b/app/Core/ORM/Relations/Relation.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Core\ORM\Relations;
+
+use App\Core\ORM\Model;
+use App\Core\ORM\QueryBuilder;
+
+abstract class Relation implements \Countable
+{
+    protected bool $initialized = false;
+
+    protected mixed $results = null;
+
+    public function __construct(protected Model $parent, protected QueryBuilder $query)
+    {
+    }
+
+    public function getQuery(): QueryBuilder
+    {
+        return $this->query;
+    }
+
+    public function getResults(): mixed
+    {
+        if ($this->initialized) {
+            return $this->results;
+        }
+
+        $this->results = $this->resolve();
+        $this->initialized = true;
+
+        return $this->results;
+    }
+
+    public function refresh(): void
+    {
+        $this->initialized = false;
+        $this->results = null;
+    }
+
+    public function __call(string $method, array $parameters): mixed
+    {
+        $results = $this->getResults();
+        if ($results === null) {
+            return null;
+        }
+
+        return $results->$method(...$parameters);
+    }
+
+    public function __get(string $name): mixed
+    {
+        $results = $this->getResults();
+        if ($results === null) {
+            return null;
+        }
+
+        return $results->$name;
+    }
+
+    public function __isset(string $name): bool
+    {
+        $results = $this->getResults();
+        if ($results === null) {
+            return false;
+        }
+
+        return isset($results->$name);
+    }
+
+    public function count(): int
+    {
+        $results = $this->getResults();
+        if ($results === null) {
+            return 0;
+        }
+
+        if (is_array($results) || $results instanceof \Countable) {
+            return count($results);
+        }
+
+        return 1;
+    }
+
+    abstract protected function resolve(): mixed;
+}

--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -1,68 +1,346 @@
 <?php
 
-declare(strict_types=1);
-
 namespace App\Core;
 
-final class Router
+use App\Core\Contracts\Middleware as MiddlewareContract;
+use Closure;
+use RuntimeException;
+
+class Router
 {
-    /** @var array<string, array<int, array{pattern:string, handler: callable|array}>> */
-    private array $routes = ['GET' => [], 'POST' => []];
+    /** @var array<int, array<string, mixed>> */
+    private array $routes = [];
 
-    public function get(string $path, callable|array $handler): void
-    {
-        $this->add('GET', $path, $handler);
-    }
-    public function post(string $path, callable|array $handler): void
-    {
-        $this->add('POST', $path, $handler);
-    }
+    /** @var array<int, array<string, mixed>> */
+    private array $groupStack = [];
 
-    private function add(string $method, string $path, callable|array $handler): void
+    /** @var array<string, array<string, mixed>> */
+    private array $namedRoutes = [];
+
+    public function group(array $attributes, callable $callback): void
     {
-        $pattern = $this->compile($path);
-        $this->routes[$method][] = ['pattern' => $pattern, 'handler' => $handler];
+        $this->groupStack[] = $this->mergeGroupAttributes($attributes);
+        $callback($this);
+        array_pop($this->groupStack);
     }
 
-    private function compile(string $path): string
+    public function get(string $uri, callable|array|string $action, array $options = []): void
     {
-        if ($path === '/' || $path === '') return '#^/$#';
-        $regex = preg_replace('#\{([a-zA-Z_][a-zA-Z0-9_]*)\}#', '(?P<$1>[^/]+)', $path);
-        $regex = rtrim($regex, '/');
-        return '#^' . $regex . '/?$#';
+        $this->addRoute(['GET'], $uri, $action, $options);
     }
 
-    public function dispatch(string $method, string $path): void
+    public function post(string $uri, callable|array|string $action, array $options = []): void
     {
-        $path = rtrim($path, '/') ?: '/';
-        foreach ($this->routes[$method] ?? [] as $r) {
-            if (preg_match($r['pattern'], $path, $m)) {
-                $params = array_filter($m, 'is_string', ARRAY_FILTER_USE_KEY);
-                $this->invoke($r['handler'], $params);
-                return;
+        $this->addRoute(['POST'], $uri, $action, $options);
+    }
+
+    public function put(string $uri, callable|array|string $action, array $options = []): void
+    {
+        $this->addRoute(['PUT'], $uri, $action, $options);
+    }
+
+    public function patch(string $uri, callable|array|string $action, array $options = []): void
+    {
+        $this->addRoute(['PATCH'], $uri, $action, $options);
+    }
+
+    public function delete(string $uri, callable|array|string $action, array $options = []): void
+    {
+        $this->addRoute(['DELETE'], $uri, $action, $options);
+    }
+
+    public function any(string $uri, callable|array|string $action, array $options = []): void
+    {
+        $this->addRoute(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], $uri, $action, $options);
+    }
+
+    public function addRoute(array $methods, string $uri, callable|array|string $action, array $options = []): void
+    {
+        $uri = '/' . ltrim($uri, '/');
+        $attributes = $this->mergeGroupAttributes($options);
+
+        $route = [
+            'methods' => array_unique(array_map('strtoupper', $methods)),
+            'uri' => $this->prependGroupPrefix($uri),
+            'action' => $action,
+            'middleware' => $this->normalizeMiddleware($attributes['middleware'] ?? []),
+            'name' => $this->prependNamePrefix($attributes['as'] ?? null),
+            'json' => $attributes['json'] ?? false,
+        ];
+
+        $this->routes[] = $route;
+
+        if ($route['name']) {
+            $this->namedRoutes[$route['name']] = $route;
+        }
+    }
+
+    public function dispatch(Request $request, Container $container): Response
+    {
+        $method = $request->method();
+        $path = rtrim($request->uri(), '/') ?: '/';
+
+        foreach ($this->routes as $route) {
+            if (!in_array($method, $route['methods'], true)) {
+                continue;
+            }
+
+            $pattern = $this->compileRoute($route['uri']);
+            if (preg_match($pattern, $path, $matches)) {
+                $parameters = $this->extractParameters($matches);
+                return $this->runRoute($route, $parameters, $request, $container);
             }
         }
 
-        http_response_code(404);
-        $root    = dirname(__DIR__, 2);
-        $view404 = $root . '/app/Views/errors/404.php';
-        if (is_file($view404)) {
-            // Make BASE_URL available if view wants it
-            $baseUrl = defined('BASE_URL') ? BASE_URL : '';
-            require $view404;
-            return;
+        if ($request->expectsJson()) {
+            return Response::json(['status' => 'error', 'message' => 'Route not found.'], 404);
         }
-        echo '404 Not Found';
+
+        return new Response(View::render('errors/404', ['uri' => $path]), 404);
     }
 
-    private function invoke(callable|array $handler, array $params): void
+    public function url(string $name, array $parameters = []): string
     {
-        if (is_array($handler)) {
-            [$class, $method] = $handler;
-            $obj = new $class();
-            $obj->$method($params);
-            return;
+        if (!isset($this->namedRoutes[$name])) {
+            throw new RuntimeException(sprintf('Route "%s" is not defined.', $name));
         }
-        $handler($params);
+
+        $uri = $this->namedRoutes[$name]['uri'];
+        foreach ($parameters as $key => $value) {
+            $uri = str_replace('{' . $key . '}', $value, $uri);
+        }
+
+        return $uri;
+    }
+
+    private function runRoute(array $route, array $parameters, Request $request, Container $container): Response
+    {
+        $response = $this->runMiddlewarePipeline($route['middleware'], $request, function (Request $request) use ($route, $parameters, $container) {
+            $callable = $this->resolveAction($route['action'], $container);
+            $result = $callable($request, ...array_values($parameters));
+            return $this->prepareResponse($result, $request, $route);
+        }, $container);
+
+        return $response;
+    }
+
+    private function runMiddlewarePipeline(array $middlewares, Request $request, callable $destination, Container $container): Response
+    {
+        $pipeline = array_reduce(
+            array_reverse($middlewares),
+            function ($next, $middleware) use ($container) {
+                return function (Request $request) use ($next, $middleware, $container) {
+                    $parameters = [];
+                    if (is_string($middleware)) {
+                        if (str_contains($middleware, ':')) {
+                            [$middlewareClass, $parameterString] = explode(':', $middleware, 2);
+                            $middleware = $middlewareClass;
+                            $parameters = $parameterString !== '' ? explode(',', $parameterString) : [];
+                        }
+                        $instance = $container->make($middleware);
+                        if (method_exists($instance, 'setParameters')) {
+                            $instance->setParameters($parameters);
+                        }
+                    } else {
+                        $instance = $middleware;
+                    }
+
+                    if ($instance instanceof MiddlewareContract) {
+                        return $instance->handle($request, $next);
+                    }
+
+                    if (is_callable($instance)) {
+                        return $instance($request, $next);
+                    }
+
+                    throw new RuntimeException('Invalid middleware provided.');
+                };
+            },
+            $destination
+        );
+
+        return $pipeline($request);
+    }
+
+    private function prepareResponse(mixed $result, Request $request, array $route): Response
+    {
+        if ($result instanceof Response) {
+            return $result;
+        }
+
+        if (is_array($result)) {
+            return Response::json($result);
+        }
+
+        if (is_string($result)) {
+            return new Response($result);
+        }
+
+        if ($result === null) {
+            return new Response('', 204);
+        }
+
+        if ($route['json'] || $request->expectsJson()) {
+            return Response::json(['data' => $result]);
+        }
+
+        return new Response((string) $result);
+    }
+
+    private function resolveAction(callable|array|string $action, Container $container): callable
+    {
+        if (is_callable($action)) {
+            return $action;
+        }
+
+        if (is_array($action) && count($action) === 2) {
+            [$class, $method] = $action;
+            $controller = is_string($class) ? $container->make($class) : $class;
+            if ($controller instanceof Controller) {
+                $controller->setContainer($container);
+            }
+            return [$controller, $method];
+        }
+
+        if (is_string($action) && str_contains($action, '@')) {
+            [$class, $method] = explode('@', $action);
+            $controller = $container->make($class);
+            if ($controller instanceof Controller) {
+                $controller->setContainer($container);
+            }
+
+            return [$controller, $method];
+        }
+
+        throw new RuntimeException('Invalid route action.');
+    }
+
+    private function compileRoute(string $uri): string
+    {
+        $pattern = preg_replace('#\{([^}/]+)\}#', '(?P<$1>[^/]+)', rtrim($uri, '/') ?: '/');
+        return '#^' . $pattern . '$#';
+    }
+
+    private function extractParameters(array $matches): array
+    {
+        $parameters = [];
+        foreach ($matches as $key => $value) {
+            if (is_string($key)) {
+                $parameters[$key] = $value;
+            }
+        }
+
+        return $parameters;
+    }
+
+    private function mergeGroupAttributes(array $attributes): array
+    {
+        $stacked = $this->groupStack;
+        $merged = ['middleware' => [], 'prefix' => '', 'as' => null, 'json' => false];
+
+        foreach ($stacked as $group) {
+            $merged['middleware'] = array_merge(
+                $merged['middleware'],
+                $this->normalizeMiddleware($group['middleware'] ?? [])
+            );
+            $merged['prefix'] .= $group['prefix'] ?? '';
+            $merged['as'] = $this->concatenateName($merged['as'], $group['as'] ?? null);
+            $merged['json'] = $merged['json'] || ($group['json'] ?? false);
+        }
+
+        $merged['middleware'] = array_merge(
+            $merged['middleware'],
+            $this->normalizeMiddleware($attributes['middleware'] ?? [])
+        );
+        if (isset($attributes['prefix'])) {
+            $merged['prefix'] .= $attributes['prefix'];
+        }
+        $merged['as'] = $this->concatenateName($merged['as'], $attributes['as'] ?? null);
+        $merged['json'] = $merged['json'] || ($attributes['json'] ?? false);
+        $merged['middleware'] = $this->uniqueMiddleware($merged['middleware']);
+
+        return $merged;
+    }
+
+    private function prependGroupPrefix(string $uri): string
+    {
+        $prefix = '';
+        foreach ($this->groupStack as $group) {
+            if (!empty($group['prefix'])) {
+                $prefix .= '/' . trim($group['prefix'], '/');
+            }
+        }
+
+        return rtrim('/' . trim($prefix . '/' . ltrim($uri, '/'), '/'), '/') ?: '/';
+    }
+
+    private function prependNamePrefix(?string $name): ?string
+    {
+        $prefix = '';
+        foreach ($this->groupStack as $group) {
+            if (!empty($group['as'])) {
+                $prefix .= $group['as'];
+            }
+        }
+
+        if ($name === null) {
+            return $prefix ?: null;
+        }
+
+        return $prefix . $name;
+    }
+
+    private function concatenateName(?string $base, ?string $append): ?string
+    {
+        if (!$base) {
+            return $append;
+        }
+
+        if (!$append) {
+            return $base;
+        }
+
+        return $base . $append;
+    }
+
+    private function normalizeMiddleware(mixed $middleware): array
+    {
+        if ($middleware === null || $middleware === []) {
+            return [];
+        }
+
+        if (is_string($middleware)) {
+            return [$middleware];
+        }
+
+        if (!is_array($middleware)) {
+            return [$middleware];
+        }
+
+        $normalized = [];
+        foreach ($middleware as $item) {
+            $normalized = array_merge($normalized, $this->normalizeMiddleware($item));
+        }
+
+        return $normalized;
+    }
+
+    private function uniqueMiddleware(array $middleware): array
+    {
+        $unique = [];
+        $seenStrings = [];
+
+        foreach ($middleware as $item) {
+            if (is_string($item)) {
+                if (isset($seenStrings[$item])) {
+                    continue;
+                }
+                $seenStrings[$item] = true;
+            }
+
+            $unique[] = $item;
+        }
+
+        return $unique;
     }
 }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Core\ORM\EntityManager;
+use App\Core\ORM\Model;
+use App\Core\ORM\QueryBuilder;
+
+abstract class BaseRepository
+{
+    /** @var array<class-string<Model>, string> */
+    private array $primaryKeyCache = [];
+
+    public function __construct(protected EntityManager $entityManager)
+    {
+    }
+
+    abstract protected function model(): string;
+
+    public function query(): QueryBuilder
+    {
+        /** @var class-string<Model> $model */
+        $model = $this->model();
+        return $model::query();
+    }
+
+    public function find(mixed $id): ?Model
+    {
+        return $this->query()->find($id);
+    }
+
+    public function create(array $attributes): Model
+    {
+        /** @var class-string<Model> $model */
+        $model = $this->model();
+        return $model::create($attributes);
+    }
+
+    public function update(mixed $id, array $attributes): bool
+    {
+        return (bool) $this->query()->where($this->primaryKey(), '=', $id)->update($attributes);
+    }
+
+    public function delete(mixed $id): bool
+    {
+        return (bool) $this->query()->where($this->primaryKey(), '=', $id)->delete();
+    }
+
+    public function paginate(int $perPage = 15, int $page = 1): array
+    {
+        return $this->query()->paginate($perPage, $page);
+    }
+
+    protected function primaryKey(): string
+    {
+        /** @var class-string<Model> $model */
+        $model = $this->model();
+        if (!isset($this->primaryKeyCache[$model])) {
+            $this->primaryKeyCache[$model] = $model::keyName();
+        }
+
+        return $this->primaryKeyCache[$model];
+    }
+}

--- a/app/Services/ResumeService.php
+++ b/app/Services/ResumeService.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\ORM\EntityManager;
+use App\Models\Resume;
+use App\Repositories\BillingRepository;
+use App\Repositories\ResumeBuilderRepository;
+use App\Repositories\ResumeRepository;
+use App\Repositories\ResumeUnlockRepository;
+use App\Services\Notifications\NotificationService;
+use JsonException;
+use RuntimeException;
+
+class ResumeService
+{
+    public function __construct(
+        private EntityManager $entityManager,
+        private ResumeRepository $resumes,
+        private ResumeBuilderRepository $builders,
+        private ResumeUnlockRepository $unlocks,
+        private BillingRepository $billing,
+        private NotificationService $notifications
+    ) {
+    }
+
+    public function upload(array $payload): Resume
+    {
+        /** @var Resume $resume */
+        $resume = $this->resumes->create($payload);
+        $this->notifications->notify($payload['candidate_id'], 'Resume uploaded', ['resume_id' => $resume->getKey()]);
+        return $resume;
+    }
+
+    public function generate(int $candidateId, array $data): Resume
+    {
+        return $this->entityManager->transaction(function () use ($candidateId, $data) {
+            $relativePath = $this->buildGeneratedResume($candidateId, $data);
+
+            $builder = $this->builders->create([
+                'candidate_id' => $candidateId,
+                'template' => $data['template'] ?? 'modern',
+                'data' => $data,
+                'generated_path' => $relativePath,
+            ]);
+
+            $resume = $this->resumes->create([
+                'candidate_id' => $candidateId,
+                'title' => $data['title'] ?? 'Generated Resume',
+                'file_path' => $relativePath,
+                'content' => $this->encodeResumeData($data),
+                'is_generated' => true,
+                'visibility' => $data['visibility'] ?? 'private',
+            ]);
+
+            $this->notifications->notify($candidateId, 'Resume generated', [
+                'resume_id' => $resume->getKey(),
+                'builder_id' => $builder->getKey(),
+            ]);
+
+            return $resume;
+        });
+    }
+
+    public function unlock(int $resumeId, int $userId, int $credits = 1): bool
+    {
+        $billing = $this->billing->forUser($userId);
+        if (!$billing || $billing->getAttribute('credits_balance') < $credits) {
+            return false;
+        }
+
+        $billing->fill(['credits_balance' => $billing->getAttribute('credits_balance') - $credits]);
+        $billing->save();
+
+        $this->unlocks->create([
+            'resume_id' => $resumeId,
+            'unlocked_by' => $userId,
+            'credits_used' => $credits,
+            'unlocked_at' => now(),
+        ]);
+
+        $this->notifications->notify($userId, 'Resume unlocked', ['resume_id' => $resumeId]);
+        return true;
+    }
+
+    private function buildGeneratedResume(int $candidateId, array $data): string
+    {
+        $directory = storage_path('resumes');
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException(sprintf('Unable to create resume storage directory at %s.', $directory));
+        }
+
+        $filename = sprintf('candidate_%d_%s.html', $candidateId, bin2hex(random_bytes(8)));
+        $relativePath = 'resumes/' . $filename;
+        $fullPath = $directory . DIRECTORY_SEPARATOR . $filename;
+
+        $html = $this->renderResumeTemplate($data);
+        if (file_put_contents($fullPath, $html) === false) {
+            throw new RuntimeException(sprintf('Unable to write generated resume to %s.', $fullPath));
+        }
+
+        return $relativePath;
+    }
+
+    private function renderResumeTemplate(array $data): string
+    {
+        $name = $this->escape((string) ($data['name'] ?? 'Candidate'));
+        $headlineValue = trim((string) ($data['headline'] ?? ($data['title'] ?? '')));
+        $headline = $headlineValue !== '' ? '<p class="headline">' . $this->escape($headlineValue) . '</p>' : '';
+
+        $contactParts = [];
+        foreach (['email', 'phone', 'location'] as $field) {
+            if (!empty($data[$field])) {
+                $contactParts[] = '<span>' . $this->escape((string) $data[$field]) . '</span>';
+            }
+        }
+        $contact = $contactParts ? '<div class="contact">' . implode(' • ', $contactParts) . '</div>' : '';
+
+        $summaryValue = trim((string) ($data['summary'] ?? ''));
+        $summary = $summaryValue !== ''
+            ? '<section><h2>Summary</h2><p>' . nl2br($this->escape($summaryValue), false) . '</p></section>'
+            : '';
+
+        $experienceItems = '';
+        foreach ((array) ($data['experience'] ?? []) as $item) {
+            $role = trim((string) ($item['role'] ?? ($item['title'] ?? '')));
+            if ($role === '') {
+                continue;
+            }
+
+            $company = trim((string) ($item['company'] ?? ''));
+            $period = trim((string) ($item['period'] ?? ''));
+            $description = trim((string) ($item['description'] ?? ''));
+
+            $line = '<strong>' . $this->escape($role) . '</strong>';
+            if ($company !== '') {
+                $line .= ' at ' . $this->escape($company);
+            }
+            if ($period !== '') {
+                $line .= ' <em>(' . $this->escape($period) . ')</em>';
+            }
+
+            $experienceItems .= '<li>' . $line;
+            if ($description !== '') {
+                $experienceItems .= '<div>' . nl2br($this->escape($description), false) . '</div>';
+            }
+            $experienceItems .= '</li>';
+        }
+        $experience = $experienceItems !== ''
+            ? '<section><h2>Experience</h2><ul>' . $experienceItems . '</ul></section>'
+            : '';
+
+        $skillsItems = '';
+        foreach ((array) ($data['skills'] ?? []) as $skill) {
+            $skill = trim((string) $skill);
+            if ($skill === '') {
+                continue;
+            }
+            $skillsItems .= '<li>' . $this->escape($skill) . '</li>';
+        }
+        $skills = $skillsItems !== ''
+            ? '<section><h2>Skills</h2><ul class="skills">' . $skillsItems . '</ul></section>'
+            : '';
+
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{$name} — Resume</title>
+    <style>
+        body { font-family: Arial, sans-serif; color: #1f2933; margin: 0; padding: 32px; background: #f9fafb; }
+        h1 { margin-bottom: 0; font-size: 28px; }
+        h2 { font-size: 18px; border-bottom: 1px solid #d9e2ec; padding-bottom: 4px; text-transform: uppercase; letter-spacing: 1px; color: #102a43; }
+        .contact { margin-top: 4px; color: #486581; }
+        .headline { color: #243b53; margin-top: 8px; font-weight: 600; }
+        section { margin-top: 24px; }
+        ul { padding-left: 18px; }
+        ul.skills { display: flex; flex-wrap: wrap; list-style: none; padding: 0; margin: 0; }
+        ul.skills li { background: #e1effe; color: #1d4ed8; padding: 4px 8px; border-radius: 12px; margin: 4px 8px 4px 0; }
+        li { margin-bottom: 12px; }
+        li div { margin-top: 6px; color: #334e68; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>{$name}</h1>
+        {$contact}
+        {$headline}
+    </header>
+    <main>
+        {$summary}
+        {$experience}
+        {$skills}
+    </main>
+</body>
+</html>
+HTML;
+    }
+
+    private function encodeResumeData(array $data): string
+    {
+        try {
+            return json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Unable to encode resume data to JSON.', 0, $exception);
+        }
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/database/migrations/202410130001_create_users_table.php
+++ b/database/migrations/202410130001_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) NOT NULL UNIQUE,
+            password VARCHAR(255) NOT NULL,
+            role VARCHAR(50) NOT NULL,
+            api_token VARCHAR(255) NULL,
+            last_login_at DATETIME NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS users');
+    }
+};

--- a/database/migrations/202410130002_create_candidates_table.php
+++ b/database/migrations/202410130002_create_candidates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS candidates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            headline VARCHAR(255) NULL,
+            summary TEXT NULL,
+            experience_years INTEGER DEFAULT 0,
+            location VARCHAR(255) NULL,
+            skills TEXT NULL,
+            visibility VARCHAR(50) DEFAULT "public",
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS candidates');
+    }
+};

--- a/database/migrations/202410130003_create_employers_table.php
+++ b/database/migrations/202410130003_create_employers_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS employers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            company_name VARCHAR(255) NOT NULL,
+            website VARCHAR(255) NULL,
+            industry VARCHAR(100) NULL,
+            company_size VARCHAR(50) NULL,
+            verified_at DATETIME NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS employers');
+    }
+};

--- a/database/migrations/202410130004_create_recruiters_table.php
+++ b/database/migrations/202410130004_create_recruiters_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS recruiters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            agency_name VARCHAR(255) NULL,
+            license_number VARCHAR(100) NULL,
+            verified_at DATETIME NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS recruiters');
+    }
+};

--- a/database/migrations/202410130005_create_admins_table.php
+++ b/database/migrations/202410130005_create_admins_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS admins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            super_admin BOOLEAN DEFAULT 0,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS admins');
+    }
+};

--- a/database/migrations/202410130006_create_job_postings_table.php
+++ b/database/migrations/202410130006_create_job_postings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS job_postings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            employer_id INTEGER NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            description TEXT NOT NULL,
+            location VARCHAR(255) NULL,
+            salary INTEGER NULL,
+            currency VARCHAR(10) DEFAULT "USD",
+            type VARCHAR(50) DEFAULT "full-time",
+            status VARCHAR(50) DEFAULT "open",
+            published_at DATETIME NULL,
+            expires_at DATETIME NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (employer_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS job_postings');
+    }
+};

--- a/database/migrations/202410130007_create_resumes_table.php
+++ b/database/migrations/202410130007_create_resumes_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS resumes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id INTEGER NOT NULL,
+            title VARCHAR(255) NOT NULL,
+            file_path VARCHAR(255) NULL,
+            content TEXT NULL,
+            is_generated BOOLEAN DEFAULT 0,
+            visibility VARCHAR(50) DEFAULT "private",
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (candidate_id) REFERENCES candidates(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS resumes');
+    }
+};

--- a/database/migrations/202410130008_create_applications_table.php
+++ b/database/migrations/202410130008_create_applications_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS applications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_posting_id INTEGER NOT NULL,
+            candidate_id INTEGER NOT NULL,
+            cover_letter TEXT NULL,
+            status VARCHAR(50) DEFAULT "submitted",
+            submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (job_posting_id) REFERENCES job_postings(id),
+            FOREIGN KEY (candidate_id) REFERENCES candidates(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS applications');
+    }
+};

--- a/database/migrations/202410130009_create_payments_table.php
+++ b/database/migrations/202410130009_create_payments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS payments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            amount INTEGER NOT NULL,
+            currency VARCHAR(10) NOT NULL,
+            status VARCHAR(50) NOT NULL,
+            provider VARCHAR(50) NOT NULL,
+            reference VARCHAR(255) NOT NULL,
+            meta TEXT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS payments');
+    }
+};

--- a/database/migrations/202410130010_create_billing_table.php
+++ b/database/migrations/202410130010_create_billing_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS billing (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            credits_balance INTEGER DEFAULT 0,
+            plan VARCHAR(100) DEFAULT "free",
+            renews_at DATETIME NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS billing');
+    }
+};

--- a/database/migrations/202410130011_create_contact_form_table.php
+++ b/database/migrations/202410130011_create_contact_form_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS contact_form (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) NOT NULL,
+            subject VARCHAR(255) NULL,
+            message TEXT NOT NULL,
+            status VARCHAR(50) DEFAULT "new",
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS contact_form');
+    }
+};

--- a/database/migrations/202410130012_create_micro_questions_table.php
+++ b/database/migrations/202410130012_create_micro_questions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS micro_questions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            question TEXT NOT NULL,
+            category VARCHAR(100) NULL,
+            difficulty VARCHAR(50) NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS micro_questions');
+    }
+};

--- a/database/migrations/202410130013_create_job_micro_questions_table.php
+++ b/database/migrations/202410130013_create_job_micro_questions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS job_micro_questions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_posting_id INTEGER NOT NULL,
+            micro_question_id INTEGER NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (job_posting_id) REFERENCES job_postings(id),
+            FOREIGN KEY (micro_question_id) REFERENCES micro_questions(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS job_micro_questions');
+    }
+};

--- a/database/migrations/202410130014_create_application_answers_table.php
+++ b/database/migrations/202410130014_create_application_answers_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS application_answers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            application_id INTEGER NOT NULL,
+            micro_question_id INTEGER NOT NULL,
+            answer TEXT NULL,
+            score INTEGER NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (application_id) REFERENCES applications(id),
+            FOREIGN KEY (micro_question_id) REFERENCES micro_questions(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS application_answers');
+    }
+};

--- a/database/migrations/202410130015_create_password_resets_table.php
+++ b/database/migrations/202410130015_create_password_resets_table.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS password_resets (
+            email VARCHAR(255) NOT NULL,
+            token VARCHAR(255) NOT NULL,
+            created_at DATETIME NOT NULL
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS password_resets');
+    }
+};

--- a/database/migrations/202410130016_create_login_attempts_table.php
+++ b/database/migrations/202410130016_create_login_attempts_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS login_attempts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email VARCHAR(255) NOT NULL,
+            ip_address VARCHAR(45) NULL,
+            succeeded BOOLEAN DEFAULT 0,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS login_attempts');
+    }
+};

--- a/database/migrations/202410130017_create_resume_builder_table.php
+++ b/database/migrations/202410130017_create_resume_builder_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS resume_builder (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id INTEGER NOT NULL,
+            template VARCHAR(100) NOT NULL,
+            data TEXT NULL,
+            generated_path VARCHAR(255) NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (candidate_id) REFERENCES candidates(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS resume_builder');
+    }
+};

--- a/database/migrations/202410130018_create_job_languages_table.php
+++ b/database/migrations/202410130018_create_job_languages_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS job_languages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_posting_id INTEGER NOT NULL,
+            language VARCHAR(100) NOT NULL,
+            proficiency VARCHAR(50) NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (job_posting_id) REFERENCES job_postings(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS job_languages');
+    }
+};

--- a/database/migrations/202410130019_create_resume_unlocks_table.php
+++ b/database/migrations/202410130019_create_resume_unlocks_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Core\Database\Migration;
+
+return new class extends Migration {
+    public function up(PDO $pdo): void
+    {
+        $pdo->exec('CREATE TABLE IF NOT EXISTS resume_unlocks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            resume_id INTEGER NOT NULL,
+            unlocked_by INTEGER NOT NULL,
+            credits_used INTEGER DEFAULT 1,
+            unlocked_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (resume_id) REFERENCES resumes(id),
+            FOREIGN KEY (unlocked_by) REFERENCES users(id)
+        )');
+    }
+
+    public function down(PDO $pdo): void
+    {
+        $pdo->exec('DROP TABLE IF EXISTS resume_unlocks');
+    }
+};

--- a/tests/Services/PaymentServiceTest.php
+++ b/tests/Services/PaymentServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Repositories\BillingRepository;
+use App\Repositories\PaymentRepository;
+use App\Services\AccountService;
+use App\Services\PaymentService;
+use PHPUnit\Framework\TestCase;
+
+class PaymentServiceTest extends TestCase
+{
+    private PaymentService $payments;
+    private AccountService $accounts;
+    private BillingRepository $billing;
+    private PaymentRepository $paymentRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $container = $GLOBALS['app']->container();
+        $this->payments = $container->make(PaymentService::class);
+        $this->accounts = $container->make(AccountService::class);
+        $this->billing = $container->make(BillingRepository::class);
+        $this->paymentRepository = $container->make(PaymentRepository::class);
+    }
+
+    public function test_it_records_charges_and_updates_credit_balances(): void
+    {
+        $employer = $this->accounts->registerEmployer([
+            'name' => 'Payments Employer',
+            'email' => 'payments-' . uniqid('', true) . '@example.com',
+            'password' => 'secret',
+            'company_name' => 'Payments LLC',
+        ]);
+
+        $billing = $this->billing->forUser($employer->getKey());
+        $this->assertNotNull($billing);
+        $initialCredits = (int) $billing->getAttribute('credits_balance');
+
+        $payload = [
+            'amount' => 4999,
+            'currency' => 'usd',
+            'credits' => 5,
+            'description' => 'Professional credits pack',
+        ];
+
+        $charge = $this->payments->charge($employer->getKey(), $payload);
+
+        $this->assertSame('succeeded', $charge['status']);
+        $this->assertSame($payload['amount'], $charge['amount']);
+        $this->assertSame($payload['currency'], $charge['currency']);
+
+        $updatedBilling = $this->billing->forUser($employer->getKey());
+        $this->assertNotNull($updatedBilling);
+        $this->assertSame($initialCredits + $payload['credits'], (int) $updatedBilling->getAttribute('credits_balance'));
+
+        $records = $this->paymentRepository->forUser($employer->getKey());
+        $this->assertNotEmpty($records);
+
+        /** @var App\Models\Payment $latest */
+        $latest = $records[0];
+        $this->assertSame($charge['id'], $latest->getAttribute('reference'));
+        $this->assertSame('stripe', $latest->getAttribute('provider'));
+        $this->assertSame('succeeded', $latest->getAttribute('status'));
+        $this->assertSame($payload['amount'], (int) $latest->getAttribute('amount'));
+
+        $meta = $latest->getAttribute('meta');
+        $this->assertIsArray($meta);
+        $this->assertSame($payload['credits'], (int) ($meta['credits'] ?? 0));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize middleware handling in the router so grouped and route-specific stacks support multiple entries and CSRF protection
- enhance API helpers and account pagination responses, add resume generation with real file output, and extend the ORM with safer primary-key lookup, casting, and relation proxies
- add MySQL-friendly migration bookkeeping, defensive seeder execution, and a payment service regression test while updating migrations for timestamps

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68ce1967755483288a0cfbea9c32a782