### PR TITLE
Refactor front controller to use Request/Response pipeline

### DIFF
--- a/app/Controllers/HomeController.php
+++ b/app/Controllers/HomeController.php
@@ -4,29 +4,39 @@ declare(strict_types=1);
 
 namespace App\Controllers;
 
+use App\Core\Request;
+
 final class HomeController
 {
-    public function index(array $params = []): void
+    private function renderLayout(string $title, string $viewFile): string
     {
-        $root     = dirname(__DIR__, 2);
-        $title    = 'HireMe — Hiring in Malaysia, simplified.';
+        $root = dirname(__DIR__, 2);
+        ob_start();
+        require $root . '/app/Views/layout.php';
+        return (string) ob_get_clean();
+    }
+
+    public function index(Request $request): string
+    {
+        $root = dirname(__DIR__, 2);
+        $title = 'HireMe — Hiring in Malaysia, simplified.';
         $viewFile = $root . '/app/Views/home.php';
-        require $root . '/app/Views/layout.php';
+        return $this->renderLayout($title, $viewFile);
     }
 
-    public function privacy(array $params = []): void
+    public function privacy(Request $request): string
     {
-        $root     = dirname(__DIR__, 2);
-        $title    = 'Privacy Policy — HireMe';
+        $root = dirname(__DIR__, 2);
+        $title = 'Privacy Policy — HireMe';
         $viewFile = $root . '/app/Views/privacy.php';
-        require $root . '/app/Views/layout.php';
+        return $this->renderLayout($title, $viewFile);
     }
 
-    public function terms(array $params = []): void
+    public function terms(Request $request): string
     {
-        $root     = dirname(__DIR__, 2);
-        $title    = 'Terms of Service — HireMe';
+        $root = dirname(__DIR__, 2);
+        $title = 'Terms of Service — HireMe';
         $viewFile = $root . '/app/Views/terms.php';
-        require $root . '/app/Views/layout.php';
+        return $this->renderLayout($title, $viewFile);
     }
 }

--- a/app/Core/Container.php
+++ b/app/Core/Container.php
@@ -4,33 +4,169 @@ declare(strict_types=1);
 
 namespace App\Core;
 
+use Closure;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionNamedType;
+use RuntimeException;
+
 /**
- * Simple dependency injection container.
+ * Simple dependency injection container capable of resolving class
+ * dependencies via reflection. Supports registering shared instances and
+ * singleton factories while remaining lightweight for the application.
  */
 final class Container
 {
-    /** @var array<string,mixed> */
-    private array $entries = [];
+    /** @var array<string, mixed> */
+    private array $instances = [];
+
+    /** @var array<string, array{factory: Closure, singleton: bool}> */
+    private array $bindings = [];
 
     /**
-     * Register a value or factory with the container.
-     *
-     * @param string $id
-     * @param mixed $value
+     * Register a concrete value with the container.
      */
     public function set(string $id, mixed $value): void
     {
-        $this->entries[$id] = $value;
+        $this->instances[$id] = $value;
+        unset($this->bindings[$id]);
+    }
+
+    /**
+     * Determine whether the container knows about the given id.
+     */
+    public function has(string $id): bool
+    {
+        return array_key_exists($id, $this->instances) || array_key_exists($id, $this->bindings);
     }
 
     /**
      * Retrieve a value from the container.
-     *
-     * @param string $id
-     * @return mixed
      */
     public function get(string $id): mixed
     {
-        return $this->entries[$id] ?? null;
+        if (array_key_exists($id, $this->instances)) {
+            return $this->instances[$id];
+        }
+
+        if (array_key_exists($id, $this->bindings)) {
+            return $this->make($id);
+        }
+
+        return null;
+    }
+
+    /**
+     * Register a shared instance with the container.
+     */
+    public function instance(string $id, mixed $instance): void
+    {
+        $this->instances[$id] = $instance;
+        unset($this->bindings[$id]);
+    }
+
+    /**
+     * Register a singleton factory.
+     */
+    public function singleton(string $id, callable $factory): void
+    {
+        $this->bindings[$id] = [
+            'factory' => $this->normalizeFactory($factory),
+            'singleton' => true,
+        ];
+    }
+
+    /**
+     * Register a factory that creates a new instance each time.
+     */
+    public function bind(string $id, callable $factory): void
+    {
+        $this->bindings[$id] = [
+            'factory' => $this->normalizeFactory($factory),
+            'singleton' => false,
+        ];
+    }
+
+    /**
+     * Resolve an entry from the container.
+     *
+     * @throws RuntimeException When the entry cannot be resolved.
+     */
+    public function make(string $id): mixed
+    {
+        if (array_key_exists($id, $this->instances)) {
+            return $this->instances[$id];
+        }
+
+        if (isset($this->bindings[$id])) {
+            $binding = $this->bindings[$id];
+            $value = $this->callFactory($binding['factory']);
+            if ($binding['singleton']) {
+                $this->instances[$id] = $value;
+            }
+
+            return $value;
+        }
+
+        if (!class_exists($id)) {
+            throw new RuntimeException(sprintf('Class or binding "%s" is not resolvable.', $id));
+        }
+
+        $reflection = new ReflectionClass($id);
+        if (!$reflection->isInstantiable()) {
+            throw new RuntimeException(sprintf('Class "%s" is not instantiable.', $id));
+        }
+
+        $constructor = $reflection->getConstructor();
+        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
+            $instance = $reflection->newInstance();
+            $this->instances[$id] = $instance;
+
+            return $instance;
+        }
+
+        $arguments = [];
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                $arguments[] = $this->make($type->getName());
+                continue;
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $arguments[] = $parameter->getDefaultValue();
+                continue;
+            }
+
+            throw new RuntimeException(sprintf(
+                'Unable to resolve parameter "%s" for "%s".',
+                $parameter->getName(),
+                $id
+            ));
+        }
+
+        $instance = $reflection->newInstanceArgs($arguments);
+        $this->instances[$id] = $instance;
+
+        return $instance;
+    }
+
+    /**
+     * Normalise a callable to a closure for later execution.
+     */
+    private function normalizeFactory(callable $factory): Closure
+    {
+        return $factory instanceof Closure ? $factory : Closure::fromCallable($factory);
+    }
+
+    /**
+     * Execute a stored factory closure, injecting the container when required.
+     */
+    private function callFactory(Closure $factory): mixed
+    {
+        $reflection = new ReflectionFunction($factory);
+        $arguments = $reflection->getNumberOfParameters() > 0 ? [$this] : [];
+
+        return $factory(...$arguments);
     }
 }

--- a/app/Core/Request.php
+++ b/app/Core/Request.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use JsonException;
+
+final class Request
+{
+    private array $query;
+    private array $body;
+    private array $cookies;
+    private array $files;
+    private array $server;
+    private array $headers;
+    private string $method;
+    private string $path;
+    private ?string $rawBody;
+    private ?array $jsonCache = null;
+    private ?string $basePath;
+
+    public function __construct(
+        array $query = [],
+        array $body = [],
+        array $cookies = [],
+        array $files = [],
+        array $server = [],
+        ?string $rawBody = null,
+        ?string $basePath = null
+    ) {
+        $this->query = $query;
+        $this->body = $body;
+        $this->cookies = $cookies;
+        $this->files = $files;
+        $this->server = $server;
+        $this->rawBody = $rawBody;
+        $this->basePath = $basePath !== null ? rtrim($basePath, '/') : null;
+
+        $this->method = strtoupper($server['REQUEST_METHOD'] ?? 'GET');
+        $this->headers = $this->parseHeaders($server);
+        $this->path = $this->normalisePath($server['REQUEST_URI'] ?? '/', $this->basePath);
+    }
+
+    public static function fromGlobals(?string $basePath = null): self
+    {
+        $input = file_get_contents('php://input');
+        return new self(
+            $_GET,
+            $_POST,
+            $_COOKIE,
+            $_FILES,
+            $_SERVER,
+            $input === false ? null : $input,
+            $basePath
+        );
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    public function uri(): string
+    {
+        return $this->path;
+    }
+
+    public function basePath(): ?string
+    {
+        return $this->basePath;
+    }
+
+    public function query(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $this->query;
+        }
+
+        return $this->query[$key] ?? $default;
+    }
+
+    public function input(?string $key = null, mixed $default = null): mixed
+    {
+        $data = $this->all();
+        if ($key === null) {
+            return $data;
+        }
+
+        return $data[$key] ?? $default;
+    }
+
+    public function all(): array
+    {
+        return array_replace_recursive($this->query, $this->body, $this->json() ?? []);
+    }
+
+    public function json(?string $key = null, mixed $default = null): mixed
+    {
+        $decoded = $this->decodeJson();
+        if ($decoded === null) {
+            return $key === null ? null : $default;
+        }
+
+        if ($key === null) {
+            return $decoded;
+        }
+
+        return $decoded[$key] ?? $default;
+    }
+
+    public function cookie(string $key, mixed $default = null): mixed
+    {
+        return $this->cookies[$key] ?? $default;
+    }
+
+    public function file(string $key, mixed $default = null): mixed
+    {
+        return $this->files[$key] ?? $default;
+    }
+
+    public function server(string $key, mixed $default = null): mixed
+    {
+        $key = strtoupper($key);
+        return $this->server[$key] ?? $default;
+    }
+
+    public function header(string $name, mixed $default = null): mixed
+    {
+        $normalized = $this->normaliseHeaderName($name);
+        return $this->headers[$normalized] ?? $default;
+    }
+
+    public function headers(): array
+    {
+        return $this->headers;
+    }
+
+    public function bearerToken(): ?string
+    {
+        $header = $this->header('Authorization');
+        if (!is_string($header)) {
+            return null;
+        }
+
+        if (preg_match('/Bearer\\s+(.*)$/i', $header, $matches)) {
+            return trim($matches[1]);
+        }
+
+        return null;
+    }
+
+    public function expectsJson(): bool
+    {
+        $accept = (string) $this->header('Accept', '');
+        if ($accept !== '' && str_contains(strtolower($accept), 'json')) {
+            return true;
+        }
+
+        $requestedWith = (string) $this->header('X-Requested-With', '');
+        if (strcasecmp($requestedWith, 'XMLHttpRequest') === 0) {
+            return true;
+        }
+
+        $contentType = (string) $this->header('Content-Type', '');
+        return str_contains(strtolower($contentType), 'json');
+    }
+
+    public function isAjax(): bool
+    {
+        return strcasecmp((string) $this->header('X-Requested-With', ''), 'XMLHttpRequest') === 0;
+    }
+
+    public function ip(): ?string
+    {
+        foreach (['HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR'] as $key) {
+            $value = $this->server[$key] ?? null;
+            if (is_string($value) && $value !== '') {
+                $parts = explode(',', $value);
+                return trim($parts[0]);
+            }
+        }
+
+        return null;
+    }
+
+    public function userAgent(): ?string
+    {
+        $agent = $this->server['HTTP_USER_AGENT'] ?? null;
+        return is_string($agent) ? $agent : null;
+    }
+
+    public function rawBody(): ?string
+    {
+        return $this->rawBody;
+    }
+
+    private function decodeJson(): ?array
+    {
+        if ($this->jsonCache !== null) {
+            return $this->jsonCache;
+        }
+
+        $contentType = strtolower((string) $this->header('Content-Type', ''));
+        if ($this->rawBody === null || $this->rawBody === '' || !str_contains($contentType, 'json')) {
+            $this->jsonCache = [];
+            return $this->jsonCache;
+        }
+
+        try {
+            /** @var array<string, mixed>|null $decoded */
+            $decoded = json_decode($this->rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            $this->jsonCache = [];
+            return $this->jsonCache;
+        }
+
+        $this->jsonCache = $decoded ?? [];
+        return $this->jsonCache;
+    }
+
+    private function parseHeaders(array $server): array
+    {
+        $headers = [];
+        foreach ($server as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            if (str_starts_with($key, 'HTTP_')) {
+                $headers[$this->normaliseHeaderName(substr($key, 5))] = $value;
+                continue;
+            }
+
+            if (in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true)) {
+                $headers[$this->normaliseHeaderName($key)] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    private function normaliseHeaderName(string $name): string
+    {
+        $name = str_replace('-', '_', $name);
+        $name = preg_replace('/[^A-Za-z0-9_]/', '', $name) ?? $name;
+        $segments = explode('_', strtolower($name));
+        $segments = array_map(static fn (string $segment) => ucfirst($segment), $segments);
+        return implode('-', $segments);
+    }
+
+    private function normalisePath(string $uri, ?string $basePath): string
+    {
+        $path = str_replace('\\', '/', parse_url($uri, PHP_URL_PATH) ?? '/');
+        $path = $path !== '' ? $path : '/';
+
+        if ($basePath) {
+            $basePath = '/' . ltrim($basePath, '/');
+            if (str_starts_with($path, $basePath)) {
+                $path = substr($path, strlen($basePath)) ?: '/';
+            }
+        }
+
+        $path = rtrim($path, '/') ?: '/';
+        if ($path === '/index.php') {
+            $path = '/';
+        }
+
+        return $path;
+    }
+}

--- a/app/Core/Response.php
+++ b/app/Core/Response.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use JsonException;
+
+final class Response
+{
+    private string $body;
+    private int $status;
+    /** @var array<string, array<int, string>> */
+    private array $headers = [];
+
+    public function __construct(string $body = '', int $status = 200, array $headers = [])
+    {
+        $this->body = $body;
+        $this->status = $status;
+        foreach ($headers as $name => $value) {
+            $values = is_array($value) ? array_values(array_map('strval', $value)) : [(string) $value];
+            $this->headers[$this->normalizeHeaderName($name)] = $values;
+        }
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function headers(): array
+    {
+        return $this->headers;
+    }
+
+    public function setBody(string $body): self
+    {
+        $this->body = $body;
+        return $this;
+    }
+
+    public function setStatus(int $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+
+    public function header(string $name, string $value, bool $replace = true): self
+    {
+        $normalized = $this->normalizeHeaderName($name);
+        if ($replace || !isset($this->headers[$normalized])) {
+            $this->headers[$normalized] = [$value];
+        } else {
+            $this->headers[$normalized][] = $value;
+        }
+
+        return $this;
+    }
+
+    public function send(): void
+    {
+        http_response_code($this->status);
+        foreach ($this->headers as $name => $values) {
+            foreach ($values as $value) {
+                header($name . ': ' . $value, false);
+            }
+        }
+
+        echo $this->body;
+    }
+
+    public static function json(mixed $data, int $status = 200, array $headers = []): self
+    {
+        try {
+            $body = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException) {
+            $body = json_encode(['error' => 'Unable to encode response'], JSON_UNESCAPED_UNICODE);
+            $status = 500;
+        }
+
+        $headers = ['Content-Type' => 'application/json'] + $headers;
+
+        return new self($body ?: '', $status, $headers);
+    }
+
+    private function normalizeHeaderName(string $name): string
+    {
+        $name = strtolower($name);
+        $segments = explode('-', $name);
+        $segments = array_map(static fn (string $segment) => ucfirst($segment), $segments);
+        return implode('-', $segments);
+    }
+}

--- a/app/Core/View.php
+++ b/app/Core/View.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use RuntimeException;
+
+final class View
+{
+    public static function render(string $view, array $data = []): string
+    {
+        $basePath = dirname(__DIR__) . '/Views/';
+        $viewPath = $basePath . ltrim($view, '/') . '.php';
+
+        if (!is_file($viewPath)) {
+            throw new RuntimeException(sprintf('View "%s" not found.', $view));
+        }
+
+        extract($data, EXTR_SKIP);
+        ob_start();
+        require $viewPath;
+        return (string) ob_get_clean();
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Core\Request;
 use App\Core\Router;
 use App\Controllers\HomeController;
 use App\Controllers\AuthController;
@@ -200,12 +201,6 @@ $router->post('/api/users/{type}', [UserController::class, 'store']);
 $router->get('/api/accounts/{type}/{id}', [AccountController::class, 'apiShow']);
 $router->post('/api/accounts/{type}', [AccountController::class, 'apiCreate']);
 
-// Normalize path relative to BASE_URL (avoid str_starts_with for PHP 7+)
-$method  = strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET');
-$uriPath = str_replace('\\', '/', parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/');
-$base    = defined('BASE_URL') ? BASE_URL : '';
-$path    = ($base && substr($uriPath, 0, strlen($base)) === $base) ? substr($uriPath, strlen($base)) : $uriPath;
-$path    = rtrim($path, '/') ?: '/';
-if ($path === '/index.php') $path = '/';
-
-$router->dispatch($method, $path);
+$request = Request::fromGlobals(defined('BASE_URL') ? BASE_URL : null);
+$response = $router->dispatch($request, $container);
+$response->send();

--- a/tests/HomeRouteSmokeTest.php
+++ b/tests/HomeRouteSmokeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+use App\Core\DB;
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+DB::setConnection($pdo);
+
+$_GET = [];
+$_POST = [];
+$_COOKIE = [];
+$_FILES = [];
+$_SERVER = [
+    'REQUEST_METHOD' => 'GET',
+    'REQUEST_URI' => '/',
+    'SCRIPT_NAME' => '/index.php',
+    'SERVER_PROTOCOL' => 'HTTP/1.1',
+    'HTTP_ACCEPT' => 'text/html',
+];
+
+ob_start();
+require __DIR__ . '/../public/index.php';
+$output = ob_get_clean();
+
+assert(str_contains($output, 'HireMe — Hiring in Malaysia, simplified.'), 'Home page should include the marketing headline.');
+
+echo "Home route smoke test passed\n";


### PR DESCRIPTION
## Summary
- add lightweight dependency container, request, response, and view helpers to support the router’s new signature
- update the front controller and HomeController to dispatch with the new Request/Response flow
- add a CLI smoke test that exercises the home route with an in-memory database

## Testing
- php tests/JobServiceTest.php
- php tests/HomeRouteSmokeTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cea721f5e48328a951a3cc2873fbbb