### PR TITLE
Fix router argument resolution for legacy params controllers

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -4,6 +4,14 @@ namespace App\Core;
 
 use App\Core\Contracts\Middleware as MiddlewareContract;
 use Closure;
+use ReflectionException;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
+use ReflectionIntersectionType;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionUnionType;
 use RuntimeException;
 
 class Router
@@ -115,13 +123,157 @@ class Router
 
     private function runRoute(array $route, array $parameters, Request $request, Container $container): Response
     {
-        $response = $this->runMiddlewarePipeline($route['middleware'], $request, function (Request $request) use ($route, $parameters, $container) {
-            $callable = $this->resolveAction($route['action'], $container);
-            $result = $callable($request, ...array_values($parameters));
-            return $this->prepareResponse($result, $request, $route);
-        }, $container);
+        $response = $this->runMiddlewarePipeline(
+            $route['middleware'],
+            $request,
+            function (Request $request) use ($route, $parameters, $container) {
+                $callable = $this->resolveAction($route['action'], $container);
+                $arguments = $this->resolveActionArguments($callable, $parameters, $request);
+                $result = $callable(...$arguments);
+
+                return $this->prepareResponse($result, $request, $route);
+            },
+            $container
+        );
 
         return $response;
+    }
+
+    /**
+     * @param callable $callable
+     * @param array<string, mixed> $parameters
+     * @return array<int, mixed>
+     */
+    private function resolveActionArguments(callable $callable, array $parameters, Request $request): array
+    {
+        $reflection = $this->reflectCallable($callable);
+        $routeValues = array_values($parameters);
+
+        if ($reflection === null) {
+            return $routeValues;
+        }
+
+        $arguments = [];
+        $remaining = $routeValues;
+        $paramsArrayProvided = false;
+
+        foreach ($reflection->getParameters() as $parameter) {
+            if ($this->parameterExpectsRequest($parameter)) {
+                $arguments[] = $request;
+                continue;
+            }
+
+            if (!$paramsArrayProvided && $this->parameterExpectsParamsArray($parameter)) {
+                $arguments[] = $parameters;
+                $paramsArrayProvided = true;
+                continue;
+            }
+
+            if ($parameter->isVariadic()) {
+                $arguments = array_merge($arguments, $remaining);
+                $remaining = [];
+                continue;
+            }
+
+            if ($remaining !== []) {
+                $arguments[] = array_shift($remaining);
+                continue;
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                continue;
+            }
+
+            $arguments[] = null;
+        }
+
+        return $arguments;
+    }
+
+    private function reflectCallable(callable $callable): ?ReflectionFunctionAbstract
+    {
+        try {
+            if ($callable instanceof Closure) {
+                return new ReflectionFunction($callable);
+            }
+
+            if (is_array($callable)) {
+                return new ReflectionMethod($callable[0], $callable[1]);
+            }
+
+            if (is_string($callable)) {
+                if (str_contains($callable, '::')) {
+                    return new ReflectionMethod($callable);
+                }
+
+                return new ReflectionFunction($callable);
+            }
+
+            if (is_object($callable) && method_exists($callable, '__invoke')) {
+                return new ReflectionMethod($callable, '__invoke');
+            }
+
+            return new ReflectionFunction(Closure::fromCallable($callable));
+        } catch (ReflectionException) {
+            return null;
+        }
+    }
+
+    private function parameterExpectsRequest(ReflectionParameter $parameter): bool
+    {
+        $type = $parameter->getType();
+
+        if ($type instanceof ReflectionNamedType) {
+            return $this->typeMatchesRequest($type);
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $named) {
+                if ($named instanceof ReflectionNamedType && $this->typeMatchesRequest($named)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            foreach ($type->getTypes() as $named) {
+                if ($named instanceof ReflectionNamedType && $this->typeMatchesRequest($named)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function parameterExpectsParamsArray(ReflectionParameter $parameter): bool
+    {
+        $type = $parameter->getType();
+
+        if ($type instanceof ReflectionNamedType) {
+            return $type->isBuiltin() && $type->getName() === 'array';
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $named) {
+                if ($named instanceof ReflectionNamedType && $named->isBuiltin() && $named->getName() === 'array') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function typeMatchesRequest(ReflectionNamedType $type): bool
+    {
+        if ($type->isBuiltin()) {
+            return false;
+        }
+
+        $name = $type->getName();
+
+        return $name === Request::class || is_a($name, Request::class, true);
     }
 
     private function runMiddlewarePipeline(array $middlewares, Request $request, callable $destination, Container $container): Response

--- a/tests/RouterLegacyParamsTest.php
+++ b/tests/RouterLegacyParamsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+use App\Core\DB;
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE employers (
+    employer_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company_name TEXT,
+    company_logo TEXT
+)');
+
+$pdo->exec('CREATE TABLE job_postings (
+    job_posting_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company_id INTEGER,
+    recruiter_id INTEGER,
+    job_title TEXT,
+    job_description TEXT,
+    job_requirements TEXT,
+    job_location TEXT,
+    job_languages TEXT,
+    employment_type TEXT,
+    salary_range_min REAL,
+    salary_range_max REAL,
+    application_deadline TEXT,
+    date_posted TEXT,
+    status TEXT,
+    number_of_positions INTEGER,
+    required_experience TEXT,
+    education_level TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)');
+
+$pdo->exec("INSERT INTO employers (employer_id, company_name, company_logo) VALUES (1, 'Acme Corp', '')");
+$pdo->exec("INSERT INTO job_postings (
+    company_id,
+    recruiter_id,
+    job_title,
+    job_description,
+    job_requirements,
+    job_location,
+    job_languages,
+    employment_type,
+    salary_range_min,
+    salary_range_max,
+    application_deadline,
+    date_posted,
+    status,
+    number_of_positions,
+    required_experience,
+    education_level,
+    created_at,
+    updated_at
+) VALUES (
+    1,
+    NULL,
+    'Test Job',
+    'Testing description',
+    'Requirements',
+    'Kuala Lumpur',
+    'English',
+    'Full-time',
+    5000,
+    6000,
+    '2025-12-31',
+    '2024-01-01',
+    'Open',
+    1,
+    '2 years',
+    'Bachelor',
+    '2024-01-01 00:00:00',
+    '2024-01-01 00:00:00'
+)");
+
+DB::setConnection($pdo);
+
+$_GET = [];
+$_POST = [];
+$_COOKIE = [];
+$_FILES = [];
+$_SESSION = [];
+$_SERVER = [
+    'REQUEST_METHOD' => 'GET',
+    'REQUEST_URI' => '/jobs',
+    'SCRIPT_NAME' => '/index.php',
+    'SERVER_PROTOCOL' => 'HTTP/1.1',
+    'HTTP_ACCEPT' => 'text/html',
+];
+
+ob_start();
+require __DIR__ . '/../public/index.php';
+$output = ob_get_clean();
+
+assert(str_contains($output, 'Job Posts'), 'Jobs index should render the listing heading.');
+
+echo "Router legacy params test passed\n";
+


### PR DESCRIPTION
## Summary
- update the router dispatch pipeline to inspect resolved actions via reflection and build argument lists that only include the request when required
- preserve legacy parameter-array handlers while keeping route parameter expansion for additional arguments
- add a regression script that dispatches `/jobs` to ensure controllers expecting the params array continue to work

## Testing
- php tests/RouterLegacyParamsTest.php
- php tests/HomeRouteSmokeTest.php
- php tests/JobServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cebec47b348328b69a8ec2fab0e01e