### PR TITLE
Add modular API gateway for major service domains

### DIFF
--- a/app/Controllers/Api/ModuleGatewayController.php
+++ b/app/Controllers/Api/ModuleGatewayController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use App\Core\Request;
+use App\Core\Response;
+use App\Services\Modules\ModuleRegistry;
+use InvalidArgumentException;
+use Throwable;
+
+final class ModuleGatewayController extends ApiController
+{
+    private ModuleRegistry $registry;
+
+    public function __construct(?ModuleRegistry $registry = null)
+    {
+        parent::__construct();
+
+        if ($registry === null || $registry->get('user-management') === null) {
+            $this->registry = ModuleRegistry::boot();
+            return;
+        }
+
+        $this->registry = $registry;
+    }
+
+    public function handle(Request $request, string $function, string $type, ?string $id = null): Response
+    {
+        $service = $this->registry->get($function);
+        if ($service === null) {
+            return $this->error(sprintf('Unknown API module "%s".', $function), 404);
+        }
+
+        try {
+            $payload = $service->handle($type, $id, $request);
+        } catch (InvalidArgumentException $e) {
+            return $this->error($e->getMessage(), 400);
+        } catch (Throwable $e) {
+            return $this->error('Module error: ' . $e->getMessage(), 500);
+        }
+
+        return $this->success($payload);
+    }
+}

--- a/app/Services/Modules/AbstractModuleService.php
+++ b/app/Services/Modules/AbstractModuleService.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use InvalidArgumentException;
+use RuntimeException;
+
+abstract class AbstractModuleService implements ModuleServiceInterface, RegistryAwareInterface
+{
+    protected ModuleRegistry $registry;
+
+    public function setRegistry(ModuleRegistry $registry): void
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Forward a call to another module via the registry.
+     *
+     * @param string      $module Target module key or alias.
+     * @param string      $type   Operation to perform on the target module.
+     * @param string|null $id     Optional identifier to pass through.
+     * @param array<string, mixed> $query Optional query parameters.
+     * @param array<string, mixed> $body  Optional payload/body data.
+     * @param string $method HTTP method to emulate when calling the target service.
+     *
+     * @return array<string, mixed>
+     */
+    protected function forward(
+        string $module,
+        string $type,
+        ?string $id = null,
+        array $query = [],
+        array $body = [],
+        string $method = 'GET'
+    ): array {
+        $this->ensureRegistry();
+
+        return $this->registry->call($module, $type, $id, $query, $body, $method);
+    }
+
+    /**
+     * Ensure that the registry has been injected before attempting to use it.
+     */
+    protected function ensureRegistry(): void
+    {
+        if (!isset($this->registry)) {
+            throw new RuntimeException('Module registry has not been initialised for ' . static::class);
+        }
+    }
+
+    /**
+     * Helper for building a data response with an automatic module identifier.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    protected function respond(array $payload): array
+    {
+        $payload['module'] = $this->name();
+        return $payload;
+    }
+
+    /**
+     * Resolve an ID passed via the URL.
+     */
+    protected function requireId(?string $id, string $message = 'A resource identifier is required.'): string
+    {
+        if ($id === null || $id === '') {
+            throw new InvalidArgumentException($message);
+        }
+
+        return $id;
+    }
+
+    /**
+     * Convert an ID into an integer and assert it is valid.
+     */
+    protected function requireIntId(?string $id, string $message = 'A valid identifier is required.'): int
+    {
+        $id = $this->requireId($id, $message);
+        if (!ctype_digit($id)) {
+            throw new InvalidArgumentException($message);
+        }
+
+        return (int) $id;
+    }
+
+    /**
+     * Convenience helper for accessing query parameters with a fallback.
+     */
+    protected function query(Request $request, string $key, ?string $fallback = null): ?string
+    {
+        $value = $request->query($key);
+        if ($value === null) {
+            return $fallback;
+        }
+
+        return is_string($value) ? $value : $fallback;
+    }
+}

--- a/app/Services/Modules/AdminModerationService.php
+++ b/app/Services/Modules/AdminModerationService.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Models\Candidate;
+use App\Models\Employer;
+use App\Models\JobPosting;
+use App\Models\Payment;
+use InvalidArgumentException;
+
+final class AdminModerationService extends AbstractModuleService
+{
+    public function name(): string
+    {
+        return 'admin-moderation';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return match (strtolower($type)) {
+            'overview' => $this->overview(),
+            'metrics' => $this->metrics(),
+            'audit' => $this->auditLog(),
+            default => throw new InvalidArgumentException(sprintf('Unknown administration operation "%s".', $type)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function overview(): array
+    {
+        $userSnapshot = $this->forward('user-management', 'users', 'all');
+        $jobSnapshot = $this->forward('job-application', 'summary', 'all');
+        $financeSnapshot = $this->forward('payment-billing', 'summary', 'all');
+
+        $pendingVerifications = Candidate::query()->where('verified_status', 'pending')->count();
+        $flaggedJobs = JobPosting::query()->whereIn('status', ['flagged', 'under_review'])->count();
+
+        return $this->respond([
+            'overview' => [
+                'users' => $userSnapshot,
+                'jobs' => $jobSnapshot['summary'] ?? [],
+                'finance' => $financeSnapshot['summary'] ?? [],
+                'pending_verifications' => $pendingVerifications,
+                'flagged_jobs' => $flaggedJobs,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function metrics(): array
+    {
+        $candidateCount = Candidate::query()->count();
+        $employerCount = Employer::query()->count();
+        $jobCount = JobPosting::query()->count();
+        $activeJobs = JobPosting::query()->whereIn('status', ['active', 'open'])->count();
+        $failedPayments = Payment::query()->where('transaction_status', 'failed')->count();
+
+        return $this->respond([
+            'metrics' => [
+                'users' => [
+                    'candidates' => $candidateCount,
+                    'employers' => $employerCount,
+                ],
+                'jobs' => [
+                    'total' => $jobCount,
+                    'active' => $activeJobs,
+                ],
+                'payments' => [
+                    'failed' => $failedPayments,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function auditLog(): array
+    {
+        $pendingCandidates = Candidate::query()
+            ->where('verified_status', 'pending')
+            ->orderByDesc('created_at')
+            ->take(10)
+            ->get()
+            ->map(function (Candidate $candidate): array {
+                $user = $this->forward('user-management', 'user', (string) $candidate->candidate_id, [
+                    'role' => 'candidates',
+                ]);
+                return [
+                    'candidate' => $candidate->toArray(),
+                    'user' => $user['user'] ?? null,
+                ];
+            })
+            ->all();
+
+        $flaggedJobs = JobPosting::query()
+            ->whereIn('status', ['flagged', 'under_review'])
+            ->orderByDesc('updated_at')
+            ->take(10)
+            ->get()
+            ->map(function (JobPosting $job): array {
+                $employer = null;
+                if ($job->company_id !== null) {
+                    $employer = $this->forward('user-management', 'user', (string) $job->company_id, [
+                        'role' => 'employers',
+                    ]);
+                }
+
+                return [
+                    'job' => $job->toArray(),
+                    'employer' => $employer['user'] ?? null,
+                ];
+            })
+            ->all();
+
+        $failedPayments = Payment::query()
+            ->where('transaction_status', 'failed')
+            ->orderByDesc('created_at')
+            ->take(10)
+            ->get()
+            ->map(function (Payment $payment): array {
+                $user = null;
+                if ($payment->user_id !== null) {
+                    $role = $this->roleForUserType($payment->user_type);
+                    if ($role !== null) {
+                        $user = $this->forward('user-management', 'user', (string) $payment->user_id, [
+                            'role' => $role,
+                        ]);
+                    }
+                }
+
+                return [
+                    'payment' => $payment->toArray(),
+                    'user' => $user['user'] ?? null,
+                ];
+            })
+            ->all();
+
+        return $this->respond([
+            'audit' => [
+                'candidates' => $pendingCandidates,
+                'jobs' => $flaggedJobs,
+                'payments' => $failedPayments,
+            ],
+        ]);
+    }
+
+    private function roleForUserType(mixed $userType): ?string
+    {
+        if (!is_string($userType) || $userType === '') {
+            return null;
+        }
+
+        return match (strtolower($userType)) {
+            'candidate', 'candidates' => 'candidates',
+            'employer', 'employers' => 'employers',
+            'recruiter', 'recruiters' => 'recruiters',
+            'admin', 'admins' => 'admins',
+            default => null,
+        };
+    }
+}

--- a/app/Services/Modules/JobApplicationService.php
+++ b/app/Services/Modules/JobApplicationService.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use App\Models\Application;
+use App\Models\JobPosting;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+final class JobApplicationService extends AbstractModuleService
+{
+    public function name(): string
+    {
+        return 'job-application';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return match (strtolower($type)) {
+            'jobs' => $this->listJobs($request, $id),
+            'job' => $this->showJob($id),
+            'applications' => $this->listApplications($request),
+            'application' => $this->showApplication($id),
+            'summary' => $this->summarise(),
+            default => throw new InvalidArgumentException(sprintf('Unknown job/application operation "%s".', $type)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listJobs(Request $request, ?string $scope): array
+    {
+        $query = JobPosting::query()->with(['employer', 'recruiter']);
+
+        $status = $this->query($request, 'status');
+        if ($scope !== null && $scope !== '' && !ctype_digit($scope)) {
+            $scopeLower = strtolower($scope);
+            if (in_array($scopeLower, ['active', 'open'], true)) {
+                $status = $status ?? 'active';
+            } elseif (in_array($scopeLower, ['closed', 'archived'], true)) {
+                $status = $status ?? 'closed';
+            }
+        }
+
+        if ($status !== null && $status !== '') {
+            $query->where('status', $status);
+        }
+
+        if ($scope !== null && str_starts_with($scope, 'employer-')) {
+            $companyId = substr($scope, strlen('employer-'));
+            if (ctype_digit($companyId)) {
+                $query->where('company_id', (int) $companyId);
+            }
+        } elseif ($scope !== null && str_starts_with($scope, 'recruiter-')) {
+            $recruiterId = substr($scope, strlen('recruiter-'));
+            if (ctype_digit($recruiterId)) {
+                $query->where('recruiter_id', (int) $recruiterId);
+            }
+        }
+
+        if ($employer = $this->query($request, 'employer_id')) {
+            if (ctype_digit($employer)) {
+                $query->where('company_id', (int) $employer);
+            }
+        }
+
+        if ($recruiter = $this->query($request, 'recruiter_id')) {
+            if (ctype_digit($recruiter)) {
+                $query->where('recruiter_id', (int) $recruiter);
+            }
+        }
+
+        $jobs = $query->orderByDesc('date_posted')->get();
+
+        $items = $jobs->map(static function (JobPosting $posting): array {
+            $data = $posting->toArray();
+            $employer = $posting->employer;
+            if ($employer instanceof Model) {
+                $data['employer'] = $employer->toArray();
+            }
+            $recruiter = $posting->recruiter;
+            if ($recruiter instanceof Model) {
+                $data['recruiter'] = $recruiter->toArray();
+            }
+            return $data;
+        })->all();
+
+        return $this->respond([
+            'jobs' => $items,
+            'count' => count($items),
+            'filters' => [
+                'status' => $status,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showJob(?string $id): array
+    {
+        $jobId = $this->requireIntId($id, 'A job identifier is required.');
+        $job = JobPosting::query()->with(['employer', 'recruiter'])->find($jobId);
+        if ($job === null) {
+            throw new InvalidArgumentException('Job posting not found.');
+        }
+
+        $payload = $job->toArray();
+        $employer = $job->employer;
+        if ($employer instanceof Model) {
+            $payload['employer'] = $employer->toArray();
+        }
+        $recruiter = $job->recruiter;
+        if ($recruiter instanceof Model) {
+            $payload['recruiter'] = $recruiter->toArray();
+        }
+
+        $applications = Application::query()
+            ->where('job_posting_id', $jobId)
+            ->with('candidate')
+            ->get();
+
+        $payload['applications'] = $applications->map(static function (Application $application): array {
+            $data = $application->toArray();
+            $candidate = $application->candidate;
+            if ($candidate instanceof Model) {
+                $data['candidate'] = $candidate->toArray();
+            }
+            return $data;
+        })->all();
+        $payload['application_count'] = $applications->count();
+
+        return $this->respond([
+            'job' => $payload,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listApplications(Request $request): array
+    {
+        $query = Application::query()->with(['candidate', 'jobPosting']);
+
+        if ($job = $this->query($request, 'job_id')) {
+            if (ctype_digit($job)) {
+                $query->where('job_posting_id', (int) $job);
+            }
+        }
+
+        if ($candidate = $this->query($request, 'candidate_id')) {
+            if (ctype_digit($candidate)) {
+                $query->where('candidate_id', (int) $candidate);
+            }
+        }
+
+        $applications = $query->orderByDesc('created_at')->get();
+
+        $items = $applications->map(static function (Application $application): array {
+            $data = $application->toArray();
+            $candidate = $application->candidate;
+            if ($candidate instanceof Model) {
+                $data['candidate'] = $candidate->toArray();
+            }
+            $jobPosting = $application->jobPosting;
+            if ($jobPosting instanceof Model) {
+                $data['job'] = $jobPosting->toArray();
+            }
+            return $data;
+        })->all();
+
+        return $this->respond([
+            'applications' => $items,
+            'count' => count($items),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showApplication(?string $id): array
+    {
+        $applicationId = $this->requireIntId($id, 'An application identifier is required.');
+        $application = Application::query()->with(['candidate', 'jobPosting'])->find($applicationId);
+        if ($application === null) {
+            throw new InvalidArgumentException('Application record not found.');
+        }
+
+        $payload = $application->toArray();
+        $candidate = $application->candidate;
+        if ($candidate instanceof Model) {
+            $payload['candidate'] = $candidate->toArray();
+        }
+        $jobPosting = $application->jobPosting;
+        if ($jobPosting instanceof Model) {
+            $payload['job'] = $jobPosting->toArray();
+        }
+
+        if (isset($payload['candidate']['candidate_id'])) {
+            $candidateId = (string) $payload['candidate']['candidate_id'];
+            $payload['profile'] = $this->forward('resume-profile', 'profile', $candidateId);
+        }
+
+        return $this->respond([
+            'application' => $payload,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function summarise(): array
+    {
+        $totalJobs = JobPosting::query()->count();
+        $activeJobs = JobPosting::query()->whereIn('status', ['active', 'open'])->count();
+        $closedJobs = JobPosting::query()->whereIn('status', ['closed', 'archived'])->count();
+
+        $totalApplications = Application::query()->count();
+        $recentApplications = Application::query()->orderByDesc('created_at')->take(5)->get();
+        $recent = $recentApplications->map(static function (Application $application): array {
+            return $application->toArray();
+        })->all();
+
+        $topCandidates = Application::query()
+            ->selectRaw('candidate_id, COUNT(*) as total_applications')
+            ->whereNotNull('candidate_id')
+            ->groupBy('candidate_id')
+            ->orderByDesc('total_applications')
+            ->take(5)
+            ->get()
+            ->map(function ($row) {
+                $candidateId = (string) $row->candidate_id;
+                $profile = $this->forward('resume-profile', 'profile', $candidateId);
+                return [
+                    'candidate_id' => (int) $row->candidate_id,
+                    'applications' => (int) $row->total_applications,
+                    'profile' => $profile['profile'] ?? null,
+                    'resume' => $profile['resume'] ?? null,
+                ];
+            })
+            ->all();
+
+        return $this->respond([
+            'summary' => [
+                'jobs' => [
+                    'total' => $totalJobs,
+                    'active' => $activeJobs,
+                    'closed' => $closedJobs,
+                ],
+                'applications' => [
+                    'total' => $totalApplications,
+                    'recent' => $recent,
+                ],
+                'top_candidates' => $topCandidates,
+            ],
+        ]);
+    }
+}

--- a/app/Services/Modules/ModuleRegistry.php
+++ b/app/Services/Modules/ModuleRegistry.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use InvalidArgumentException;
+
+final class ModuleRegistry
+{
+    /** @var array<string, ModuleServiceInterface> */
+    private array $services = [];
+
+    /** @var array<string, string> */
+    private array $aliases = [];
+
+    public function register(ModuleServiceInterface $service, array $aliases = []): void
+    {
+        $key = strtolower($service->name());
+        $this->services[$key] = $service;
+
+        if ($service instanceof RegistryAwareInterface) {
+            $service->setRegistry($this);
+        }
+
+        $this->aliases[$key] = $key;
+        foreach ($aliases as $alias) {
+            $this->aliases[strtolower($alias)] = $key;
+        }
+    }
+
+    public function get(string $name): ?ModuleServiceInterface
+    {
+        $key = strtolower($name);
+        if (isset($this->services[$key])) {
+            return $this->services[$key];
+        }
+
+        if (isset($this->aliases[$key])) {
+            $canonical = $this->aliases[$key];
+            return $this->services[$canonical] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Invoke another module within the same process.
+     *
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $body
+     *
+     * @return array<string, mixed>
+     */
+    public function call(
+        string $module,
+        string $type,
+        ?string $id = null,
+        array $query = [],
+        array $body = [],
+        string $method = 'GET'
+    ): array {
+        $service = $this->get($module);
+        if ($service === null) {
+            throw new InvalidArgumentException(sprintf('Unknown module "%s".', $module));
+        }
+
+        $request = $this->makeRequest($query, $body, $method, $module, $type, $id);
+
+        return $service->handle($type, $id, $request);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $body
+     */
+    public function makeRequest(
+        array $query = [],
+        array $body = [],
+        string $method = 'GET',
+        ?string $module = null,
+        ?string $type = null,
+        ?string $id = null
+    ): Request {
+        $method = strtoupper($method);
+        $uri = '/internal';
+        if ($module !== null) {
+            $segments = array_filter([$module, $type, $id], static fn ($segment) => $segment !== null && $segment !== '');
+            $uri = '/internal/' . implode('/', array_map(static fn ($segment) => (string) $segment, $segments));
+        }
+
+        $server = [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $uri,
+            'HTTP_ACCEPT' => 'application/json',
+        ];
+
+        if ($method !== 'GET') {
+            $server['CONTENT_TYPE'] = 'application/json';
+        }
+
+        return new Request($query, $body, [], [], $server);
+    }
+
+    public static function boot(): self
+    {
+        $registry = new self();
+
+        $registry->register(new UserManagementService(), ['user', 'users', 'auth', 'authentication']);
+        $registry->register(new ResumeProfileService(), ['resume', 'resumes', 'profile', 'profiles']);
+        $registry->register(new JobApplicationService(), ['job', 'jobs', 'application', 'applications']);
+        $registry->register(new PaymentBillingService(), ['payment', 'payments', 'billing']);
+        $registry->register(new AdminModerationService(), ['admin', 'admins', 'moderation', 'moderator']);
+
+        return $registry;
+    }
+}

--- a/app/Services/Modules/ModuleServiceInterface.php
+++ b/app/Services/Modules/ModuleServiceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+
+interface ModuleServiceInterface
+{
+    /**
+     * Unique key used to refer to the module.
+     */
+    public function name(): string;
+
+    /**
+     * Handle an API operation for the module.
+     *
+     * @param string      $type Operation or resource identifier within the module.
+     * @param string|null $id   Optional target identifier or scope hint.
+     * @param Request     $request Incoming request data.
+     *
+     * @return array<string, mixed>
+     */
+    public function handle(string $type, ?string $id, Request $request): array;
+}

--- a/app/Services/Modules/PaymentBillingService.php
+++ b/app/Services/Modules/PaymentBillingService.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use App\Models\Billing;
+use App\Models\Payment;
+use InvalidArgumentException;
+
+final class PaymentBillingService extends AbstractModuleService
+{
+    public function name(): string
+    {
+        return 'payment-billing';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return match (strtolower($type)) {
+            'payments' => $this->listPayments($request, $id),
+            'payment' => $this->showPayment($id),
+            'billing' => $this->listBilling($request, $id),
+            'summary' => $this->summarise(),
+            default => throw new InvalidArgumentException(sprintf('Unknown payment/billing operation "%s".', $type)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listPayments(Request $request, ?string $scope): array
+    {
+        $query = Payment::query();
+
+        $status = $this->query($request, 'status');
+        if ($scope !== null && $scope !== '') {
+            $scopeLower = strtolower($scope);
+            if (in_array($scopeLower, ['pending', 'completed', 'failed', 'refunded'], true)) {
+                $status = $status ?? $scopeLower;
+            } elseif (str_starts_with($scopeLower, 'user-')) {
+                $identifier = substr($scopeLower, 5);
+                if (ctype_digit($identifier)) {
+                    $query->where('user_id', (int) $identifier);
+                }
+            }
+        }
+
+        if ($status !== null && $status !== '') {
+            $query->where('transaction_status', $status);
+        }
+
+        if ($userType = $this->query($request, 'user_type')) {
+            $query->where('user_type', $userType);
+        }
+
+        if ($userId = $this->query($request, 'user_id')) {
+            if (ctype_digit($userId)) {
+                $query->where('user_id', (int) $userId);
+            }
+        }
+
+        $payments = $query->orderByDesc('created_at')->get();
+
+        return $this->respond([
+            'payments' => $payments->map(static fn (Payment $payment) => $payment->toArray())->all(),
+            'count' => $payments->count(),
+            'filters' => [
+                'status' => $status,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showPayment(?string $id): array
+    {
+        $paymentId = $this->requireIntId($id, 'A payment identifier is required.');
+        $payment = Payment::find($paymentId);
+        if ($payment === null) {
+            throw new InvalidArgumentException('Payment record not found.');
+        }
+
+        $data = $payment->toArray();
+        $role = $this->roleForUserType($data['user_type'] ?? null);
+        if ($role !== null && isset($data['user_id']) && is_numeric($data['user_id'])) {
+            $user = $this->forward('user-management', 'user', (string) $data['user_id'], [
+                'role' => $role,
+            ]);
+            $data['user'] = $user['user'] ?? null;
+        }
+
+        return $this->respond([
+            'payment' => $data,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listBilling(Request $request, ?string $scope): array
+    {
+        $query = Billing::query();
+
+        if ($scope !== null && $scope !== '') {
+            $scopeLower = strtolower($scope);
+            if (in_array($scopeLower, ['pending', 'paid', 'failed'], true)) {
+                $query->where('status', $scopeLower);
+            } elseif (str_starts_with($scopeLower, 'user-')) {
+                $identifier = substr($scopeLower, 5);
+                if (ctype_digit($identifier)) {
+                    $query->where('user_id', (int) $identifier);
+                }
+            }
+        }
+
+        if ($status = $this->query($request, 'status')) {
+            $query->where('status', $status);
+        }
+
+        if ($userType = $this->query($request, 'user_type')) {
+            $query->where('user_type', $userType);
+        }
+
+        if ($userId = $this->query($request, 'user_id')) {
+            if (ctype_digit($userId)) {
+                $query->where('user_id', (int) $userId);
+            }
+        }
+
+        $records = $query->orderByDesc('transaction_date')->get();
+
+        return $this->respond([
+            'billing' => $records->map(static fn (Billing $billing) => $billing->toArray())->all(),
+            'count' => $records->count(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function summarise(): array
+    {
+        $totalPayments = Payment::query()->sum('amount');
+        $paymentCount = Payment::query()->count();
+
+        $statusBreakdown = Payment::query()
+            ->selectRaw('transaction_status, COUNT(*) as count, SUM(amount) as total_amount')
+            ->groupBy('transaction_status')
+            ->get()
+            ->map(static function ($row): array {
+                return [
+                    'status' => $row->transaction_status,
+                    'count' => (int) $row->count,
+                    'total_amount' => (float) $row->total_amount,
+                ];
+            })
+            ->all();
+
+        $topUsers = Payment::query()
+            ->selectRaw('user_type, user_id, SUM(amount) as total_amount, COUNT(*) as payments')
+            ->whereNotNull('user_id')
+            ->groupBy('user_type', 'user_id')
+            ->orderByDesc('total_amount')
+            ->take(5)
+            ->get()
+            ->map(function ($row): array {
+                $role = $this->roleForUserType($row->user_type);
+                $userDetails = null;
+                if ($role !== null && $row->user_id !== null) {
+                    $userDetails = $this->forward('user-management', 'user', (string) $row->user_id, [
+                        'role' => $role,
+                    ]);
+                }
+
+                return [
+                    'user_id' => (int) $row->user_id,
+                    'user_type' => $row->user_type,
+                    'total_amount' => (float) $row->total_amount,
+                    'payments' => (int) $row->payments,
+                    'user' => $userDetails['user'] ?? null,
+                ];
+            })
+            ->all();
+
+        $latestPayments = Payment::query()->orderByDesc('created_at')->take(5)->get()
+            ->map(static fn (Payment $payment) => $payment->toArray())
+            ->all();
+
+        $billingCount = Billing::query()->count();
+
+        return $this->respond([
+            'summary' => [
+                'payments' => [
+                    'total_amount' => (float) $totalPayments,
+                    'count' => $paymentCount,
+                    'by_status' => $statusBreakdown,
+                    'latest' => $latestPayments,
+                ],
+                'billing' => [
+                    'count' => $billingCount,
+                ],
+                'top_payers' => $topUsers,
+            ],
+        ]);
+    }
+
+    private function roleForUserType(mixed $userType): ?string
+    {
+        if (!is_string($userType) || $userType === '') {
+            return null;
+        }
+
+        return match (strtolower($userType)) {
+            'candidate', 'candidates' => 'candidates',
+            'employer', 'employers' => 'employers',
+            'recruiter', 'recruiters' => 'recruiters',
+            'admin', 'admins' => 'admins',
+            default => null,
+        };
+    }
+}

--- a/app/Services/Modules/RegistryAwareInterface.php
+++ b/app/Services/Modules/RegistryAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+interface RegistryAwareInterface
+{
+    public function setRegistry(ModuleRegistry $registry): void;
+}

--- a/app/Services/Modules/ResumeProfileService.php
+++ b/app/Services/Modules/ResumeProfileService.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use App\Models\Candidate;
+use App\Models\Resume;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+final class ResumeProfileService extends AbstractModuleService
+{
+    public function name(): string
+    {
+        return 'resume-profile';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return match (strtolower($type)) {
+            'resumes' => $this->listResumes($request, $id),
+            'resume' => $this->showResume($id),
+            'profiles' => $this->listProfiles($request),
+            'profile' => $this->showProfile($id),
+            default => throw new InvalidArgumentException(sprintf('Unknown resume/profile operation "%s".', $type)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listResumes(Request $request, ?string $scope): array
+    {
+        $query = Resume::query()->with('candidate');
+
+        $candidateId = null;
+        if ($scope !== null && $scope !== '' && $scope !== 'all' && ctype_digit($scope)) {
+            $candidateId = (int) $scope;
+        }
+
+        $candidateQuery = $this->query($request, 'candidate_id');
+        if ($candidateId === null && $candidateQuery !== null && ctype_digit($candidateQuery)) {
+            $candidateId = (int) $candidateQuery;
+        }
+
+        if ($candidateId !== null) {
+            $query->where('candidate_id', $candidateId);
+        }
+
+        $resumes = $query->orderByDesc('updated_at')->get();
+
+        $items = $resumes->map(static function (Resume $resume): array {
+            $data = $resume->toArray();
+            $candidate = $resume->candidate;
+            if ($candidate instanceof Model) {
+                $data['candidate'] = $candidate->toArray();
+            }
+            return $data;
+        })->all();
+
+        return $this->respond([
+            'resumes' => $items,
+            'count' => count($items),
+            'filters' => [
+                'candidate_id' => $candidateId,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showResume(?string $id): array
+    {
+        $resumeId = $this->requireIntId($id, 'A resume identifier is required.');
+        $resume = Resume::query()->with('candidate')->find($resumeId);
+        if ($resume === null) {
+            throw new InvalidArgumentException('Resume record not found.');
+        }
+
+        $payload = $resume->toArray();
+        $candidate = $resume->candidate;
+        if ($candidate instanceof Model) {
+            $payload['candidate'] = $candidate->toArray();
+        }
+
+        return $this->respond([
+            'resume' => $payload,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listProfiles(Request $request): array
+    {
+        $query = Candidate::query();
+
+        if ($status = $this->query($request, 'verified_status')) {
+            $query->where('verified_status', $status);
+        }
+
+        if ($city = $this->query($request, 'city')) {
+            $query->where('city', $city);
+        }
+
+        $candidates = $query->orderBy('full_name')->get();
+
+        return $this->respond([
+            'profiles' => $candidates->map(static fn (Candidate $candidate) => $candidate->toArray())->all(),
+            'count' => $candidates->count(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showProfile(?string $id): array
+    {
+        $candidateId = $this->requireIntId($id, 'A candidate identifier is required.');
+        $candidate = Candidate::find($candidateId);
+        if ($candidate === null) {
+            throw new InvalidArgumentException('Candidate profile not found.');
+        }
+
+        $resume = Resume::query()->where('candidate_id', $candidateId)->orderByDesc('updated_at')->first();
+
+        $userDetails = $this->forward('user-management', 'user', (string) $candidateId, [
+            'role' => 'candidates',
+        ]);
+
+        return $this->respond([
+            'profile' => $candidate->toArray(),
+            'resume' => $resume?->toArray(),
+            'user' => $userDetails['user'] ?? null,
+        ]);
+    }
+}

--- a/app/Services/Modules/UserManagementService.php
+++ b/app/Services/Modules/UserManagementService.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Modules;
+
+use App\Core\Request;
+use App\Models\Admin;
+use App\Models\Candidate;
+use App\Models\Employer;
+use App\Models\Recruiter;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+final class UserManagementService extends AbstractModuleService
+{
+    /** @var array<string, class-string<Model>> */
+    private const ROLE_MODELS = [
+        'candidates' => Candidate::class,
+        'employers' => Employer::class,
+        'recruiters' => Recruiter::class,
+        'admins' => Admin::class,
+    ];
+
+    /** @var array<string, string> */
+    private const ROLE_ALIASES = [
+        'candidate' => 'candidates',
+        'candidates' => 'candidates',
+        'talent' => 'candidates',
+        'employer' => 'employers',
+        'employers' => 'employers',
+        'company' => 'employers',
+        'recruiter' => 'recruiters',
+        'recruiters' => 'recruiters',
+        'admin' => 'admins',
+        'admins' => 'admins',
+    ];
+
+    public function name(): string
+    {
+        return 'user-management';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return match (strtolower($type)) {
+            'users' => $this->listUsers($request, $id),
+            'user' => $this->showUser($request, $id),
+            'authenticate', 'auth', 'login' => $this->authenticateUser($request),
+            default => throw new InvalidArgumentException(sprintf('Unknown user management operation "%s".', $type)),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listUsers(Request $request, ?string $scope): array
+    {
+        $roleHint = $scope !== null && $scope !== '' ? $scope : ($this->query($request, 'role') ?? 'all');
+        $role = $this->normaliseRole($roleHint);
+
+        if ($role === null || $role === 'all') {
+            $payload = [];
+            $counts = [];
+            $total = 0;
+            foreach (self::ROLE_MODELS as $roleKey => $model) {
+                $records = $model::query()->orderBy($model::CREATED_AT ?? 'created_at', 'desc')->get();
+                $payload[$roleKey] = $records->map(static fn (Model $record) => $record->toArray())->all();
+                $counts[$roleKey] = $records->count();
+                $total += $counts[$roleKey];
+            }
+
+            $counts['total'] = $total;
+
+            return $this->respond([
+                'role' => 'all',
+                'users' => $payload,
+                'counts' => $counts,
+            ]);
+        }
+
+        $modelClass = $this->modelForRole($role);
+        if ($modelClass === null) {
+            throw new InvalidArgumentException(sprintf('Unknown user role "%s".', (string) $roleHint));
+        }
+
+        $collection = $modelClass::query()->orderBy($modelClass::CREATED_AT ?? 'created_at', 'desc')->get();
+
+        return $this->respond([
+            'role' => $role,
+            'users' => $collection->map(static fn (Model $record) => $record->toArray())->all(),
+            'count' => $collection->count(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function showUser(Request $request, ?string $id): array
+    {
+        $userId = $this->requireIntId($id, 'A numeric user identifier is required.');
+        $roleHint = $this->query($request, 'role');
+
+        if ($roleHint !== null) {
+            $role = $this->normaliseRole($roleHint);
+            if ($role === null) {
+                throw new InvalidArgumentException(sprintf('Unknown user role "%s".', $roleHint));
+            }
+
+            $modelClass = $this->modelForRole($role);
+            $user = $modelClass::find($userId);
+            if ($user === null) {
+                throw new InvalidArgumentException('User record not found.');
+            }
+
+            return $this->respond([
+                'role' => $role,
+                'user' => $user->toArray(),
+            ]);
+        }
+
+        foreach (self::ROLE_MODELS as $role => $modelClass) {
+            $user = $modelClass::find($userId);
+            if ($user !== null) {
+                return $this->respond([
+                    'role' => $role,
+                    'user' => $user->toArray(),
+                ]);
+            }
+        }
+
+        throw new InvalidArgumentException('User record not found.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function authenticateUser(Request $request): array
+    {
+        $email = $this->query($request, 'email', null) ?? (string) $request->input('email', '');
+        $password = $this->query($request, 'password', null) ?? (string) $request->input('password', '');
+        if ($email === '' || $password === '') {
+            throw new InvalidArgumentException('Email and password are required for authentication.');
+        }
+
+        $roleHint = $this->query($request, 'role') ?? (string) $request->input('role', '');
+        $rolesToCheck = [];
+        if ($roleHint !== '') {
+            $role = $this->normaliseRole($roleHint);
+            if ($role === null) {
+                throw new InvalidArgumentException(sprintf('Unknown user role "%s".', $roleHint));
+            }
+            $rolesToCheck[] = $role;
+        } else {
+            $rolesToCheck = array_keys(self::ROLE_MODELS);
+        }
+
+        foreach ($rolesToCheck as $role) {
+            $modelClass = $this->modelForRole($role);
+            if ($modelClass === null) {
+                continue;
+            }
+
+            /** @var Model|null $user */
+            $user = $modelClass::query()->where('email', $email)->first();
+            if ($user === null) {
+                continue;
+            }
+
+            $data = $user->toArray();
+            $hash = $data['password_hash'] ?? null;
+            if (is_string($hash) && $hash !== '' && password_verify($password, $hash)) {
+                unset($data['password_hash']);
+
+                return $this->respond([
+                    'authenticated' => true,
+                    'role' => $role,
+                    'user' => $data,
+                ]);
+            }
+        }
+
+        return $this->respond([
+            'authenticated' => false,
+            'message' => 'Invalid credentials provided.',
+        ]);
+    }
+
+    private function normaliseRole(?string $role): ?string
+    {
+        if ($role === null) {
+            return null;
+        }
+
+        $key = strtolower(trim($role));
+        if ($key === 'all') {
+            return 'all';
+        }
+
+        if (isset(self::ROLE_ALIASES[$key])) {
+            return self::ROLE_ALIASES[$key];
+        }
+
+        return isset(self::ROLE_MODELS[$key]) ? $key : null;
+    }
+
+    /**
+     * @return class-string<Model>|null
+     */
+    private function modelForRole(string $role): ?string
+    {
+        $key = $this->normaliseRole($role);
+        return $key !== null && $key !== 'all' ? (self::ROLE_MODELS[$key] ?? null) : null;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -17,6 +17,7 @@ use App\Controllers\RecruiterCompaniesController;
 use App\Controllers\AdminController;
 use App\Controllers\AccountController;
 use App\Controllers\UserController;
+use App\Controllers\Api\ModuleGatewayController;
 use App\Controllers\Api\ResourceController;
 
 $container = require dirname(__DIR__) . '/app/bootstrap.php';
@@ -209,6 +210,10 @@ $router->post('/api/{resource}', [ResourceController::class, 'store'], ['json' =
 $router->put('/api/{resource}/{id}', [ResourceController::class, 'update'], ['json' => true]);
 $router->patch('/api/{resource}/{id}', [ResourceController::class, 'update'], ['json' => true]);
 $router->delete('/api/{resource}/{id}', [ResourceController::class, 'destroy'], ['json' => true]);
+
+// API: Module gateway endpoints (public/api/{function}/{type}/{id})
+$router->any('/public/api/{function}/{type}/{id}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
+$router->any('/public/api/{function}/{type}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
 
 $request = Request::fromGlobals(defined('BASE_URL') ? BASE_URL : null);
 $response = $router->dispatch($request, $container);


### PR DESCRIPTION
## Summary
- add an API gateway controller and registry to serve public/api/{function}/{type}/{id} requests
- implement module service layers for user management, resumes, jobs, payments, and admin moderation with cross-module forwarding
- wire the new gateway routes into the public router alongside the generic CRUD APIs

## Testing
- composer dump-autoload
- vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d12665b5008328b7fc465c19fac1c8