### PR TITLE
Implement AuthService for bearer token handling

### DIFF
--- a/app/Core/Controller.php
+++ b/app/Core/Controller.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Core;
+
+use RuntimeException;
+
+/**
+ * Base controller providing convenience helpers for dependency resolution.
+ *
+ * Controllers that are resolved through the router will have the application
+ * container injected automatically allowing child classes to fetch
+ * dependencies when required. The container is optional so controllers can
+ * still be manually instantiated in tests or scripts.
+ */
+abstract class Controller
+{
+    protected ?Container $container = null;
+
+    public function __construct(?Container $container = null)
+    {
+        if ($container !== null) {
+            $this->setContainer($container);
+        }
+    }
+
+    public function setContainer(Container $container): void
+    {
+        $this->container = $container;
+    }
+
+    protected function hasContainer(): bool
+    {
+        return $this->container instanceof Container;
+    }
+
+    protected function container(): Container
+    {
+        if (!$this->hasContainer()) {
+            throw new RuntimeException(sprintf('No container has been set on %s.', static::class));
+        }
+
+        return $this->container;
+    }
+
+    protected function make(string $id): mixed
+    {
+        return $this->container()->make($id);
+    }
+
+    protected function resolve(string $id): mixed
+    {
+        $container = $this->container();
+
+        if ($container->has($id)) {
+            return $container->get($id);
+        }
+
+        return $container->make($id);
+    }
+}

--- a/app/Services/Auth/AuthService.php
+++ b/app/Services/Auth/AuthService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Auth;
+
+use App\Models\User;
+use Throwable;
+
+/**
+ * Lightweight API authentication helper for bearer token workflows.
+ *
+ * The service intentionally keeps its responsibilities small: it can
+ * look up users by token, issue new tokens and revoke existing ones.
+ * Tokens are stored using a SHA-256 hash to avoid persisting the raw
+ * secret in the database. When reading an incoming token we transparently
+ * check both the hashed and plain forms so that existing datasets using
+ * unhashed tokens continue to function.
+ */
+final class AuthService
+{
+    /**
+     * Attempt to resolve a user model from a bearer token.
+     */
+    public function userByToken(?string $token): ?User
+    {
+        $normalised = $this->normaliseToken($token);
+        if ($normalised === null) {
+            return null;
+        }
+
+        // Prefer hashed storage but gracefully fall back to plain tokens.
+        $hashed = $this->hashToken($normalised);
+        $user = $this->findUserByStoredToken($hashed);
+        if ($user !== null) {
+            return $user;
+        }
+
+        return $this->findUserByStoredToken($normalised);
+    }
+
+    /**
+     * Generate and persist a fresh API token for the given user.
+     *
+     * @return string|null The plain token value when persistence succeeds.
+     */
+    public function issueToken(User $user): ?string
+    {
+        $token = $this->generateToken();
+        if ($token === null) {
+            return null;
+        }
+
+        if (!$this->persistToken($user, $this->hashToken($token))) {
+            return null;
+        }
+
+        return $token;
+    }
+
+    /**
+     * Remove any stored API token for the supplied user.
+     */
+    public function revokeToken(User $user): bool
+    {
+        return $this->persistToken($user, null);
+    }
+
+    private function findUserByStoredToken(string $storedToken): ?User
+    {
+        try {
+            $user = User::query()->where('api_token', $storedToken)->first();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $user instanceof User ? $user : null;
+    }
+
+    private function persistToken(User $user, ?string $storedValue): bool
+    {
+        try {
+            $user->setAttribute('api_token', $storedValue);
+
+            return $user->save();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+
+    private function normaliseToken(?string $token): ?string
+    {
+        if (!is_string($token)) {
+            return null;
+        }
+
+        $trimmed = trim($token);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function generateToken(): ?string
+    {
+        try {
+            return bin2hex(random_bytes(32));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an AuthService that resolves users from bearer tokens and manages token lifecycle

## Testing
- php -l app/Services/Auth/AuthService.php

------
https://chatgpt.com/codex/tasks/task_e_68d13f25c6a883288483e445e02ab42d