### PR TITLE
Update module gateway routes for consistent API paths

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -211,9 +211,9 @@ $router->put('/api/{resource}/{id}', [ResourceController::class, 'update'], ['js
 $router->patch('/api/{resource}/{id}', [ResourceController::class, 'update'], ['json' => true]);
 $router->delete('/api/{resource}/{id}', [ResourceController::class, 'destroy'], ['json' => true]);
 
-// API: Module gateway endpoints (public/api/{function}/{type}/{id})
-$router->any('/public/api/{function}/{type}/{id}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
-$router->any('/public/api/{function}/{type}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
+// API: Module gateway endpoints (/api/{function}/{type}/{id}) — works with or without the /public base path
+$router->any('/api/{function}/{type}/{id}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
+$router->any('/api/{function}/{type}', [ModuleGatewayController::class, 'handle'], ['json' => true]);
 
 $request = Request::fromGlobals(defined('BASE_URL') ? BASE_URL : null);
 $response = $router->dispatch($request, $container);


### PR DESCRIPTION
## Summary
- update the module gateway routes to serve /api/... endpoints so they work regardless of document root configuration

## Testing
- php verify_module_gateway.php (temporary local script confirming the routes resolve for both /public/api/... and /api/...)


------
https://chatgpt.com/codex/tasks/task_e_68d1551694188328bd8dd5164b329a89