### PR TITLE
Fix unmatched brace error in user management module

### DIFF
--- a/app/Services/Modules/UserManagementService.php
+++ b/app/Services/Modules/UserManagementService.php
@@ -113,7 +113,6 @@ final class UserManagementService extends AbstractModuleService
                 throw new InvalidArgumentException('User record not found.');
             }
 
-
             [$related, $includes] = $this->loadRelatedData($request, $role, $userId);
 
             $payload = [
@@ -130,12 +129,6 @@ final class UserManagementService extends AbstractModuleService
             }
 
             return $this->respond($payload);
-
-            return $this->respond([
-                'role' => $role,
-                'user' => $user->toArray(),
-            ]);
-
         }
 
         foreach (self::ROLE_MODELS as $role => $modelClass) {
@@ -248,16 +241,6 @@ final class UserManagementService extends AbstractModuleService
         }
 
         return [$related, $includes];
-
-                return $this->respond([
-                    'role' => $role,
-                    'user' => $user->toArray(),
-                ]);
-            }
-        }
-
-        throw new InvalidArgumentException('User record not found.');
-
     }
 
     /**


### PR DESCRIPTION
## Summary
- clean up duplicated return statements in `UserManagementService::showUser` to keep payload assembly consistent
- remove stray copied code from `loadRelatedData` that introduced unmatched braces and prevented autoloading

## Testing
- php -l app/Services/Modules/UserManagementService.php

------
https://chatgpt.com/codex/tasks/task_e_68d1581aba9883289e174dd16948d809