### PR TITLE
Fix job application ordering on legacy timestamp

### DIFF
--- a/app/Services/Modules/JobApplicationService.php
+++ b/app/Services/Modules/JobApplicationService.php
@@ -158,7 +158,7 @@ final class JobApplicationService extends AbstractModuleService
             }
         }
 
-        $applications = $query->orderByDesc('created_at')->get();
+        $applications = $query->orderByDesc('application_date')->get();
 
         $items = $applications->map(static function (Application $application): array {
             $data = $application->toArray();
@@ -220,7 +220,7 @@ final class JobApplicationService extends AbstractModuleService
         $closedJobs = JobPosting::query()->whereIn('status', ['closed', 'archived'])->count();
 
         $totalApplications = Application::query()->count();
-        $recentApplications = Application::query()->orderByDesc('created_at')->take(5)->get();
+        $recentApplications = Application::query()->orderByDesc('application_date')->take(5)->get();
         $recent = $recentApplications->map(static function (Application $application): array {
             return $application->toArray();
         })->all();

--- a/app/Services/Modules/UserManagementService.php
+++ b/app/Services/Modules/UserManagementService.php
@@ -113,7 +113,6 @@ final class UserManagementService extends AbstractModuleService
                 throw new InvalidArgumentException('User record not found.');
             }
 
-
             [$related, $includes] = $this->loadRelatedData($request, $role, $userId);
 
             $payload = [
@@ -130,12 +129,6 @@ final class UserManagementService extends AbstractModuleService
             }
 
             return $this->respond($payload);
-
-            return $this->respond([
-                'role' => $role,
-                'user' => $user->toArray(),
-            ]);
-
         }
 
         foreach (self::ROLE_MODELS as $role => $modelClass) {
@@ -248,16 +241,6 @@ final class UserManagementService extends AbstractModuleService
         }
 
         return [$related, $includes];
-
-                return $this->respond([
-                    'role' => $role,
-                    'user' => $user->toArray(),
-                ]);
-            }
-        }
-
-        throw new InvalidArgumentException('User record not found.');
-
     }
 
     /**


### PR DESCRIPTION
## Summary
- update module application listing to sort by the actual application_date column
- adjust summary "recent applications" query to use application_date for ordering

## Testing
- php -l app/Services/Modules/JobApplicationService.php

------
https://chatgpt.com/codex/tasks/task_e_68d1581aba9883289e174dd16948d809