### PR TITLE
Implement payment processor subject with observer integrations

### DIFF
--- a/app/Services/Payment/Events/GenericPaymentEvent.php
+++ b/app/Services/Payment/Events/GenericPaymentEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment\Events;
+
+use App\Services\Payment\PaymentEvent;
+
+/**
+ * Basic immutable payment event implementation used by the processor.
+ */
+final class GenericPaymentEvent implements PaymentEvent
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(private readonly string $name, private readonly array $payload)
+    {
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function payload(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app/Services/Payment/Observers/AccountingExporter.php
+++ b/app/Services/Payment/Observers/AccountingExporter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment\Observers;
+
+use App\Services\Payment\PaymentEvent;
+use App\Services\Payment\PaymentObserver;
+use App\Services\Payment\PaymentProcessor;
+
+final class AccountingExporter implements PaymentObserver
+{
+    public function __construct(private readonly string $logFile)
+    {
+    }
+
+    public function handle(PaymentEvent $event): void
+    {
+        if (!in_array($event->name(), [
+            PaymentProcessor::EVENT_INVOICE_PAID,
+            PaymentProcessor::EVENT_PAYMENT_FAILED,
+        ], true)) {
+            return;
+        }
+
+        $this->ensureDirectory();
+
+        $payload = $event->payload();
+        $record = [
+            'event' => $event->name(),
+            'user_id' => $payload['user_id'] ?? null,
+            'user_type' => $payload['user_type'] ?? null,
+            'amount' => $payload['amount'] ?? null,
+            'purpose' => $payload['purpose'] ?? null,
+            'transaction_status' => $payload['transaction_status'] ?? null,
+            'transaction_id' => $payload['transaction_id'] ?? null,
+            'recorded_at' => date('c'),
+        ];
+
+        file_put_contents($this->logFile, json_encode($record, JSON_UNESCAPED_SLASHES) . PHP_EOL, FILE_APPEND);
+    }
+
+    private function ensureDirectory(): void
+    {
+        $directory = dirname($this->logFile);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+    }
+}

--- a/app/Services/Payment/Observers/InvoiceUpdater.php
+++ b/app/Services/Payment/Observers/InvoiceUpdater.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment\Observers;
+
+use App\Models\Billing;
+use App\Services\Payment\PaymentEvent;
+use App\Services\Payment\PaymentObserver;
+use App\Services\Payment\PaymentProcessor;
+
+final class InvoiceUpdater implements PaymentObserver
+{
+    public function handle(PaymentEvent $event): void
+    {
+        if (!in_array($event->name(), [
+            PaymentProcessor::EVENT_INVOICE_PAID,
+            PaymentProcessor::EVENT_PAYMENT_FAILED,
+        ], true)) {
+            return;
+        }
+
+        $payload = $event->payload();
+        $status = $event->name() === PaymentProcessor::EVENT_INVOICE_PAID ? 'paid' : 'failed';
+        $transactionDate = (string) ($payload['processed_at'] ?? date('Y-m-d H:i:s'));
+
+        $attributes = [
+            'user_id' => (int) ($payload['user_id'] ?? 0),
+            'user_type' => (string) ($payload['user_type'] ?? ''),
+        ];
+
+        $reference = $payload['transaction_id'] ?? null;
+        if (is_string($reference) && $reference !== '') {
+            $attributes['reference_number'] = $reference;
+        }
+
+        $billing = $this->findExistingBilling($payload, $attributes);
+        $billing->fill(array_merge($attributes, [
+            'transaction_type' => $this->normaliseTransactionType((string) ($payload['purpose'] ?? '')),
+            'amount' => (float) ($payload['amount'] ?? 0),
+            'payment_method' => (string) ($payload['payment_method'] ?? 'manual'),
+            'status' => $status,
+            'transaction_date' => $transactionDate,
+        ]));
+
+        $billing->save();
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $attributes
+     */
+    private function findExistingBilling(array $payload, array $attributes): Billing
+    {
+        if (isset($payload['billing_id']) && is_numeric($payload['billing_id'])) {
+            $existing = Billing::find((int) $payload['billing_id']);
+            if ($existing instanceof Billing) {
+                return $existing;
+            }
+        }
+
+        $query = Billing::query()
+            ->where('user_id', $attributes['user_id'] ?? 0)
+            ->where('user_type', $attributes['user_type'] ?? '');
+
+        if (isset($attributes['reference_number'])) {
+            $query->where('reference_number', $attributes['reference_number']);
+        }
+
+        $existing = $query->orderByDesc('transaction_date')->first();
+        if ($existing instanceof Billing) {
+            return $existing;
+        }
+
+        $billing = new Billing();
+        $billing->fill($attributes);
+        $billing->setAttribute('transaction_date', date('Y-m-d H:i:s'));
+
+        return $billing;
+    }
+
+    private function normaliseTransactionType(string $purpose): string
+    {
+        return match (strtolower($purpose)) {
+            'resume credits', 'credits', 'credit', 'credit purchase' => 'Resume Credits',
+            'premium badge', 'premium', 'badge' => 'Premium Badge',
+            default => $purpose !== '' ? ucfirst($purpose) : 'Subscription',
+        };
+    }
+}

--- a/app/Services/Payment/Observers/SubscriptionStateManager.php
+++ b/app/Services/Payment/Observers/SubscriptionStateManager.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment\Observers;
+
+use App\Models\Candidate;
+use App\Models\Employer;
+use App\Models\Recruiter;
+use App\Services\Payment\PaymentEvent;
+use App\Services\Payment\PaymentObserver;
+use App\Services\Payment\PaymentProcessor;
+
+final class SubscriptionStateManager implements PaymentObserver
+{
+    public function handle(PaymentEvent $event): void
+    {
+        if ($event->name() !== PaymentProcessor::EVENT_INVOICE_PAID) {
+            return;
+        }
+
+        $payload = $event->payload();
+        $userType = (string) ($payload['user_type'] ?? '');
+        $userId = (int) ($payload['user_id'] ?? 0);
+        $credits = $payload['credits'] ?? null;
+        $metadata = $payload['metadata'] ?? [];
+
+        if ($credits === null && is_array($metadata) && isset($metadata['credits'])) {
+            $credits = $metadata['credits'];
+        }
+
+        if (is_numeric($credits) && (int) $credits > 0) {
+            $this->applyCredits($userType, $userId, (int) $credits);
+        }
+
+        if ($this->isPremiumPurchase($payload) && strcasecmp($userType, 'Candidate') === 0) {
+            $this->activatePremiumBadge($userId);
+        }
+    }
+
+    private function applyCredits(string $userType, int $userId, int $credits): void
+    {
+        if ($credits <= 0 || $userId <= 0) {
+            return;
+        }
+
+        $timestamp = date('Y-m-d H:i:s');
+
+        if (strcasecmp($userType, 'Employer') === 0) {
+            Employer::query()->where('employer_id', $userId)->increment('credits_balance', $credits, [
+                'updated_at' => $timestamp,
+            ]);
+
+            return;
+        }
+
+        if (strcasecmp($userType, 'Recruiter') === 0) {
+            Recruiter::query()->where('recruiter_id', $userId)->increment('credits_balance', $credits, [
+                'updated_at' => $timestamp,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function isPremiumPurchase(array $payload): bool
+    {
+        $purpose = strtolower((string) ($payload['purpose'] ?? ''));
+        if ($purpose === '') {
+            $purpose = strtolower((string) ($payload['raw_purpose'] ?? ''));
+        }
+
+        return str_contains($purpose, 'premium');
+    }
+
+    private function activatePremiumBadge(int $userId): void
+    {
+        if ($userId <= 0) {
+            return;
+        }
+
+        $timestamp = date('Y-m-d H:i:s');
+
+        Candidate::query()->where('candidate_id', $userId)->update([
+            'premium_badge' => 1,
+            'premium_badge_date' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+    }
+}

--- a/app/Services/Payment/PaymentEvent.php
+++ b/app/Services/Payment/PaymentEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment;
+
+/**
+ * Describes a payment-related event emitted by the payment processor.
+ */
+interface PaymentEvent
+{
+    /**
+     * Name of the event being emitted (e.g. "invoice_paid").
+     */
+    public function name(): string;
+
+    /**
+     * Contextual payload associated with the event.
+     *
+     * @return array<string, mixed>
+     */
+    public function payload(): array;
+}

--- a/app/Services/Payment/PaymentEventSubject.php
+++ b/app/Services/Payment/PaymentEventSubject.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment;
+
+interface PaymentEventSubject
+{
+    public function attach(string $eventName, PaymentObserver $observer): void;
+
+    public function detach(string $eventName, PaymentObserver $observer): void;
+
+    public function notify(PaymentEvent $event): void;
+}

--- a/app/Services/Payment/PaymentObserver.php
+++ b/app/Services/Payment/PaymentObserver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment;
+
+/**
+ * Contract for observers that want to react to payment events.
+ */
+interface PaymentObserver
+{
+    public function handle(PaymentEvent $event): void;
+}

--- a/app/Services/Payment/PaymentProcessor.php
+++ b/app/Services/Payment/PaymentProcessor.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Payment;
+
+use App\Models\Payment;
+use App\Services\Payment\Events\GenericPaymentEvent;
+use InvalidArgumentException;
+use SplObjectStorage;
+
+final class PaymentProcessor implements PaymentEventSubject
+{
+    public const EVENT_INVOICE_PAID = 'invoice_paid';
+    public const EVENT_PAYMENT_FAILED = 'payment_failed';
+    public const EVENT_PAYMENT_PENDING = 'payment_pending';
+
+    /** @var array<string, SplObjectStorage<PaymentObserver, null>> */
+    private array $observers = [];
+
+    /**
+     * @param array<string, iterable<PaymentObserver>> $observers
+     */
+    public function __construct(array $observers = [])
+    {
+        foreach ($observers as $event => $listeners) {
+            foreach ($listeners as $observer) {
+                $this->attach($event, $observer);
+            }
+        }
+    }
+
+    public static function withDefaultObservers(?string $logFile = null): self
+    {
+        $logFile ??= dirname(__DIR__, 3) . '/storage/logs/accounting.log';
+
+        $invoiceUpdater = new \App\Services\Payment\Observers\InvoiceUpdater();
+        $subscriptionManager = new \App\Services\Payment\Observers\SubscriptionStateManager();
+        $accountingExporter = new \App\Services\Payment\Observers\AccountingExporter($logFile);
+
+        $processor = new self();
+        $processor->attach(self::EVENT_INVOICE_PAID, $invoiceUpdater);
+        $processor->attach(self::EVENT_PAYMENT_FAILED, $invoiceUpdater);
+        $processor->attach(self::EVENT_INVOICE_PAID, $subscriptionManager);
+        $processor->attach(self::EVENT_INVOICE_PAID, $accountingExporter);
+        $processor->attach(self::EVENT_PAYMENT_FAILED, $accountingExporter);
+
+        return $processor;
+    }
+
+    public function attach(string $eventName, PaymentObserver $observer): void
+    {
+        $eventName = $this->normaliseEvent($eventName);
+        $this->observers[$eventName] ??= new SplObjectStorage();
+        $this->observers[$eventName]->attach($observer);
+    }
+
+    public function detach(string $eventName, PaymentObserver $observer): void
+    {
+        $eventName = $this->normaliseEvent($eventName);
+        if (!isset($this->observers[$eventName])) {
+            return;
+        }
+
+        $this->observers[$eventName]->detach($observer);
+        if (count($this->observers[$eventName]) === 0) {
+            unset($this->observers[$eventName]);
+        }
+    }
+
+    public function notify(PaymentEvent $event): void
+    {
+        $names = [$this->normaliseEvent($event->name())];
+        if (isset($this->observers['*'])) {
+            $names[] = '*';
+        }
+
+        foreach ($names as $name) {
+            if (!isset($this->observers[$name])) {
+                continue;
+            }
+
+            /** @var PaymentObserver $observer */
+            foreach ($this->observers[$name] as $observer) {
+                $observer->handle($event);
+            }
+        }
+    }
+
+    /**
+     * Process an incoming payment payload and broadcast the outcome.
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function process(array $attributes): PaymentEvent
+    {
+        $userId = $this->extractUserId($attributes);
+        $userType = $this->normaliseUserType((string) ($attributes['user_type'] ?? ''));
+        $purpose = $this->normalisePurpose((string) ($attributes['purpose'] ?? ''));
+        $status = $this->normaliseStatus((string) ($attributes['transaction_status'] ?? ($attributes['status'] ?? '')));
+        $amount = $this->normaliseAmount($attributes['amount'] ?? 0);
+        $paymentMethod = $this->normaliseString($attributes['payment_method'] ?? 'manual');
+        $transactionId = $this->normaliseTransactionId($attributes['transaction_id'] ?? null);
+        $metadata = $this->normaliseMetadata($attributes['metadata'] ?? null);
+        $processedAt = $attributes['processed_at'] ?? date('Y-m-d H:i:s');
+        $billingId = isset($attributes['billing_id']) && is_numeric($attributes['billing_id'])
+            ? (int) $attributes['billing_id']
+            : null;
+
+        $payment = Payment::create([
+            'user_type' => $userType,
+            'user_id' => $userId,
+            'amount' => $amount,
+            'purpose' => $purpose,
+            'payment_method' => $paymentMethod,
+            'transaction_status' => $status,
+            'transaction_id' => $transactionId,
+        ]);
+
+        $eventName = $this->eventNameForStatus($status);
+
+        $event = new GenericPaymentEvent($eventName, [
+            'payment' => $payment,
+            'user_id' => $userId,
+            'user_type' => $userType,
+            'amount' => $amount,
+            'purpose' => $purpose,
+            'raw_purpose' => $attributes['purpose'] ?? null,
+            'payment_method' => $paymentMethod,
+            'transaction_status' => $status,
+            'raw_status' => $attributes['transaction_status'] ?? ($attributes['status'] ?? null),
+            'transaction_id' => $transactionId,
+            'metadata' => $metadata,
+            'credits' => $this->extractCredits($attributes, $metadata),
+            'processed_at' => $processedAt,
+            'billing_id' => $billingId,
+        ]);
+
+        $this->notify($event);
+
+        return $event;
+    }
+
+    private function normaliseEvent(string $eventName): string
+    {
+        $eventName = trim(strtolower($eventName));
+        return $eventName === '' ? '*' : $eventName;
+    }
+
+    private function extractUserId(array $attributes): int
+    {
+        $userId = $attributes['user_id'] ?? null;
+        if ($userId === null || (!is_int($userId) && !ctype_digit((string) $userId))) {
+            throw new InvalidArgumentException('A valid user identifier is required for payment processing.');
+        }
+
+        return (int) $userId;
+    }
+
+    private function normaliseUserType(string $userType): string
+    {
+        return match (strtolower(trim($userType))) {
+            'employer', 'employers' => 'Employer',
+            'recruiter', 'recruiters' => 'Recruiter',
+            'candidate', 'candidates' => 'Candidate',
+            default => $userType !== '' ? ucfirst(strtolower($userType)) : 'Candidate',
+        };
+    }
+
+    private function normalisePurpose(string $purpose): string
+    {
+        $purpose = strtolower(trim($purpose));
+
+        return match ($purpose) {
+            'credit', 'credits', 'resume credits', 'resume_credit', 'credit_purchase', 'credit-purchase' => 'Resume Credits',
+            'premium', 'premium badge', 'badge' => 'Premium Badge',
+            'subscription', 'subscriptions', 'plan' => 'Subscription',
+            default => $purpose === '' ? 'Subscription' : ucfirst($purpose),
+        };
+    }
+
+    private function normaliseStatus(string $status): string
+    {
+        $status = strtolower(trim($status));
+
+        return match ($status) {
+            'success', 'succeeded', 'paid', 'completed' => 'Success',
+            'failed', 'failure', 'declined', 'errored' => 'Failed',
+            default => 'Pending',
+        };
+    }
+
+    private function normaliseAmount(mixed $amount): float
+    {
+        if (is_string($amount)) {
+            $clean = preg_replace('/[^0-9.\-]/', '', $amount);
+            $amount = $clean === '' ? 0.0 : (float) $clean;
+        }
+
+        if (!is_numeric($amount)) {
+            throw new InvalidArgumentException('A numeric amount is required for payment processing.');
+        }
+
+        return round((float) $amount, 2);
+    }
+
+    /**
+     * @param array<string, mixed>|string|null $metadata
+     *
+     * @return array<string, mixed>
+     */
+    private function normaliseMetadata(array|string|null $metadata): array
+    {
+        if (is_array($metadata)) {
+            return $metadata;
+        }
+
+        if (is_string($metadata) && $metadata !== '') {
+            $decoded = json_decode($metadata, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    private function extractCredits(array $attributes, array $metadata): ?int
+    {
+        $credits = $attributes['credits'] ?? ($metadata['credits'] ?? null);
+        if ($credits === null) {
+            return null;
+        }
+
+        if (is_int($credits)) {
+            return $credits;
+        }
+
+        if (is_numeric($credits)) {
+            return (int) $credits;
+        }
+
+        return null;
+    }
+
+    private function eventNameForStatus(string $status): string
+    {
+        return match ($status) {
+            'Success' => self::EVENT_INVOICE_PAID,
+            'Failed' => self::EVENT_PAYMENT_FAILED,
+            default => self::EVENT_PAYMENT_PENDING,
+        };
+    }
+
+    private function normaliseTransactionId(mixed $transactionId): ?string
+    {
+        if ($transactionId === null) {
+            return null;
+        }
+
+        $transactionId = trim((string) $transactionId);
+
+        return $transactionId === '' ? null : $transactionId;
+    }
+
+    private function normaliseString(mixed $value): string
+    {
+        $value = trim((string) $value);
+
+        return $value === '' ? 'manual' : $value;
+    }
+}

--- a/tests/Services/PaymentProcessorObserverTest.php
+++ b/tests/Services/PaymentProcessorObserverTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+use App\Models\Billing;
+use App\Models\Candidate;
+use App\Models\Employer;
+use App\Models\Payment;
+use App\Services\Modules\PaymentBillingService;
+use App\Services\Payment\Observers\AccountingExporter;
+use App\Services\Payment\Observers\InvoiceUpdater;
+use App\Services\Payment\Observers\SubscriptionStateManager;
+use App\Services\Payment\PaymentProcessor;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+$capsule = new Capsule();
+$capsule->addConnection([
+    'driver' => 'sqlite',
+    'database' => ':memory:',
+    'prefix' => '',
+]);
+$capsule->setAsGlobal();
+$capsule->bootEloquent();
+
+$pdo = $capsule->getConnection()->getPdo();
+$pdo->exec('CREATE TABLE payments (
+    payment_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_type TEXT,
+    user_id INTEGER,
+    amount REAL,
+    purpose TEXT,
+    payment_method TEXT,
+    transaction_status TEXT,
+    transaction_id TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)');
+$pdo->exec('CREATE TABLE billing (
+    billing_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    user_type TEXT,
+    transaction_type TEXT,
+    amount REAL,
+    payment_method TEXT,
+    transaction_date TEXT,
+    status TEXT,
+    reference_number TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)');
+$pdo->exec('CREATE TABLE employers (
+    employer_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company_name TEXT,
+    email TEXT,
+    credits_balance INTEGER,
+    created_at TEXT,
+    updated_at TEXT
+)');
+$pdo->exec('CREATE TABLE recruiters (
+    recruiter_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    full_name TEXT,
+    email TEXT,
+    credits_balance INTEGER,
+    created_at TEXT,
+    updated_at TEXT
+)');
+$pdo->exec('CREATE TABLE candidates (
+    candidate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    full_name TEXT,
+    email TEXT,
+    password_hash TEXT,
+    premium_badge INTEGER,
+    premium_badge_date TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)');
+
+$timestamp = date('Y-m-d H:i:s');
+$pdo->exec("INSERT INTO employers (employer_id, company_name, email, credits_balance, created_at, updated_at) VALUES (1, 'Acme Corp', 'acme@example.com', 0, '$timestamp', '$timestamp')");
+$pdo->exec("INSERT INTO candidates (candidate_id, full_name, email, password_hash, premium_badge, created_at, updated_at) VALUES (2, 'Jane Candidate', 'jane@example.com', 'secret', 0, '$timestamp', '$timestamp')");
+
+$logFile = tempnam(sys_get_temp_dir(), 'acct');
+
+$processor = new PaymentProcessor();
+$invoiceUpdater = new InvoiceUpdater();
+$subscriptionManager = new SubscriptionStateManager();
+$accountingExporter = new AccountingExporter($logFile);
+
+$processor->attach(PaymentProcessor::EVENT_INVOICE_PAID, $invoiceUpdater);
+$processor->attach(PaymentProcessor::EVENT_PAYMENT_FAILED, $invoiceUpdater);
+$processor->attach(PaymentProcessor::EVENT_INVOICE_PAID, $subscriptionManager);
+$processor->attach(PaymentProcessor::EVENT_INVOICE_PAID, $accountingExporter);
+$processor->attach(PaymentProcessor::EVENT_PAYMENT_FAILED, $accountingExporter);
+
+$service = new PaymentBillingService($processor);
+
+$successRequest = new App\Core\Request([], [
+    'user_id' => 1,
+    'user_type' => 'Employer',
+    'amount' => 4999,
+    'purpose' => 'credits',
+    'payment_method' => 'stripe',
+    'transaction_status' => 'succeeded',
+    'transaction_id' => 'pi_success_001',
+    'metadata' => ['credits' => 5],
+]);
+
+$success = $service->handle('charge', null, $successRequest);
+
+assert($success['event'] === PaymentProcessor::EVENT_INVOICE_PAID, 'Successful payments should emit the invoice_paid event.');
+assert(isset($success['payment']['transaction_status']) && $success['payment']['transaction_status'] === 'Success', 'Payment record should be normalised to Success status.');
+
+$billing = Billing::query()->where('user_id', 1)->where('user_type', 'Employer')->first();
+assert($billing instanceof Billing, 'Billing record should be created for the employer.');
+assert($billing->getAttribute('status') === 'paid', 'Billing record should be marked as paid.');
+
+$employer = Employer::find(1);
+assert($employer !== null, 'Employer should exist.');
+assert((int) $employer->getAttribute('credits_balance') === 5, 'Employer credits should increase by the purchased amount.');
+
+$logContents = file_get_contents($logFile) ?: '';
+assert(str_contains($logContents, '"event":"invoice_paid"'), 'Accounting export should log successful payments.');
+
+$failureRequest = new App\Core\Request([], [
+    'user_id' => 2,
+    'user_type' => 'Candidate',
+    'amount' => 5000,
+    'purpose' => 'premium',
+    'payment_method' => 'stripe',
+    'transaction_status' => 'failed',
+    'transaction_id' => 'pi_fail_001',
+]);
+
+$failure = $service->handle('charge', null, $failureRequest);
+
+assert($failure['event'] === PaymentProcessor::EVENT_PAYMENT_FAILED, 'Failed payments should emit the payment_failed event.');
+
+$failedBilling = Billing::query()->where('user_id', 2)->where('user_type', 'Candidate')->orderByDesc('transaction_date')->first();
+assert($failedBilling instanceof Billing, 'Billing record should be created for failed candidate payment.');
+assert($failedBilling->getAttribute('status') === 'failed', 'Billing record should be flagged as failed.');
+
+$candidate = Candidate::find(2);
+assert($candidate !== null && (int) $candidate->getAttribute('premium_badge') === 0, 'Premium badge should not be activated on failed payment.');
+
+$logContents = file_get_contents($logFile) ?: '';
+assert(str_contains($logContents, '"event":"payment_failed"'), 'Accounting export should log failed payments.');
+
+unlink($logFile);
+
+echo "Payment processor observer tests passed\n";


### PR DESCRIPTION
## Summary
- add payment event contracts and a processor that fans out invoice, subscription, and accounting events
- extend the payment billing module with a `charge` handler that delegates to the processor and surfaces results
- cover the observer workflow with a payment processor integration test

## Testing
- php tests/Services/PaymentProcessorObserverTest.php
- php tests/JobServiceTest.php
- php tests/HomeRouteSmokeTest.php
- php tests/RouterLegacyParamsTest.php *(fails: existing parse error in the legacy test script)*

------
https://chatgpt.com/codex/tasks/task_e_68d15db34248832896c53abe87074966