### PR TITLE
Introduce job module facade and centralize orchestration

### DIFF
--- a/app/Services/Job/Contracts/JobAnalyticsInterface.php
+++ b/app/Services/Job/Contracts/JobAnalyticsInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobAnalyticsInterface
+{
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function recordJobPublished(int $jobId, array $jobData): void;
+
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function recordJobUpdated(int $jobId, array $jobData): void;
+
+    /**
+     * @param callable|null $candidateProfileResolver Resolver that accepts a candidate ID and returns profile data.
+     *
+     * @return array<string, mixed>
+     */
+    public function summarise(?callable $candidateProfileResolver = null): array;
+}

--- a/app/Services/Job/Contracts/JobApplicationManagerInterface.php
+++ b/app/Services/Job/Contracts/JobApplicationManagerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobApplicationManagerInterface
+{
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    public function applyToJob(int $jobId, int $candidateId, array $input): array;
+
+    /**
+     * @param array<string, mixed> $filters
+     * @return array<int, array<string, mixed>>
+     */
+    public function listApplications(array $filters = []): array;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getApplication(int $applicationId): ?array;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listForJob(int $jobId): array;
+}

--- a/app/Services/Job/Contracts/JobAuthorizerInterface.php
+++ b/app/Services/Job/Contracts/JobAuthorizerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobAuthorizerInterface
+{
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function authorizePublish(string $role, int $userId, array $jobData): void;
+
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function authorizeUpdate(int $jobId, string $role, int $userId, array $jobData): void;
+
+    public function authorizeApplication(int $jobId, int $candidateId): void;
+}

--- a/app/Services/Job/Contracts/JobNotifierInterface.php
+++ b/app/Services/Job/Contracts/JobNotifierInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobNotifierInterface
+{
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function jobPublished(int $jobId, array $jobData): void;
+
+    /**
+     * @param array<string, mixed> $jobData
+     */
+    public function jobUpdated(int $jobId, array $jobData): void;
+
+    public function applicationSubmitted(int $applicationId): void;
+}

--- a/app/Services/Job/Contracts/JobRepositoryInterface.php
+++ b/app/Services/Job/Contracts/JobRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobRepositoryInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     * @param array<int, int> $questionIds
+     */
+    public function createJob(array $data, array $questionIds = []): int;
+
+    /**
+     * @param array<string, mixed> $data
+     * @param array<int, int> $questionIds
+     */
+    public function updateJob(int $jobId, array $data, array $questionIds = []): bool;
+}

--- a/app/Services/Job/Contracts/JobSearchInterface.php
+++ b/app/Services/Job/Contracts/JobSearchInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobSearchInterface
+{
+    public function refreshJob(int $jobId): void;
+
+    /**
+     * @param array<string, mixed> $filters
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(array $filters = []): array;
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getJob(int $jobId): ?array;
+}

--- a/app/Services/Job/Contracts/JobValidatorInterface.php
+++ b/app/Services/Job/Contracts/JobValidatorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job\Contracts;
+
+interface JobValidatorInterface
+{
+    /**
+     * Validate and normalise data for publishing a job.
+     *
+     * @param array<string, mixed> $input
+     *
+     * @return array{data: array<string, mixed>, errors: array<string, string>}
+     */
+    public function validateForPublish(string $role, int $userId, array $input): array;
+
+    /**
+     * Validate and normalise data for updating a job.
+     *
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $existing
+     *
+     * @return array{data: array<string, mixed>, errors: array<string, string>}
+     */
+    public function validateForUpdate(string $role, int $userId, array $input, array $existing = []): array;
+}

--- a/app/Services/Job/JobAnalyticsService.php
+++ b/app/Services/Job/JobAnalyticsService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Models\Application;
+use App\Models\JobPosting;
+use App\Services\Job\Contracts\JobAnalyticsInterface;
+
+final class JobAnalyticsService implements JobAnalyticsInterface
+{
+    public function recordJobPublished(int $jobId, array $jobData): void
+    {
+        // Analytics tracking could be added here.
+    }
+
+    public function recordJobUpdated(int $jobId, array $jobData): void
+    {
+        // Analytics tracking could be added here.
+    }
+
+    public function summarise(?callable $candidateProfileResolver = null): array
+    {
+        $totalJobs = JobPosting::query()->count();
+        $activeJobs = JobPosting::query()->whereIn('status', ['active', 'open'])->count();
+        $closedJobs = JobPosting::query()->whereIn('status', ['closed', 'archived'])->count();
+
+        $totalApplications = Application::query()->count();
+        $recentApplications = Application::query()->orderByDesc('application_date')->take(5)->get();
+        $recent = $recentApplications->map(static function (Application $application): array {
+            return $application->toArray();
+        })->all();
+
+        $topCandidatesQuery = Application::query()
+            ->selectRaw('candidate_id, COUNT(*) as total_applications')
+            ->whereNotNull('candidate_id')
+            ->groupBy('candidate_id')
+            ->orderByDesc('total_applications')
+            ->take(5)
+            ->get();
+
+        $topCandidates = $topCandidatesQuery->map(function ($row) use ($candidateProfileResolver): array {
+            $candidateId = (int) $row->candidate_id;
+            $resolved = null;
+            if ($candidateProfileResolver !== null && $candidateId > 0) {
+                $resolved = $candidateProfileResolver($candidateId);
+            }
+
+            return [
+                'candidate_id' => $candidateId,
+                'applications' => (int) $row->total_applications,
+                'profile' => is_array($resolved) ? ($resolved['profile'] ?? null) : null,
+                'resume' => is_array($resolved) ? ($resolved['resume'] ?? null) : null,
+            ];
+        })->all();
+
+        return [
+            'summary' => [
+                'jobs' => [
+                    'total' => $totalJobs,
+                    'active' => $activeJobs,
+                    'closed' => $closedJobs,
+                ],
+                'applications' => [
+                    'total' => $totalApplications,
+                    'recent' => $recent,
+                ],
+                'top_candidates' => $topCandidates,
+            ],
+        ];
+    }
+}

--- a/app/Services/Job/JobApplicationWorkflow.php
+++ b/app/Services/Job/JobApplicationWorkflow.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Models\Application;
+use App\Services\Job\Contracts\JobApplicationManagerInterface;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Eloquent\Model;
+
+final class JobApplicationWorkflow implements JobApplicationManagerInterface
+{
+    public function applyToJob(int $jobId, int $candidateId, array $input): array
+    {
+        if ($candidateId <= 0) {
+            return ['application_id' => 0, 'errors' => ['general' => 'Authentication required.']];
+        }
+
+        $answers = $input['answers'] ?? [];
+        $now = date('Y-m-d H:i:s');
+
+        return Capsule::connection()->transaction(static function () use ($jobId, $candidateId, $answers, $now, $input) {
+            $existing = Application::query()
+                ->where('candidate_id', $candidateId)
+                ->where('job_posting_id', $jobId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existing !== null && strtolower((string) $existing->application_status) !== 'withdrawn') {
+                return [
+                    'application_id' => (int) $existing->getKey(),
+                    'errors' => ['general' => 'You have already applied to this job.'],
+                ];
+            }
+
+            $reapplied = false;
+            if ($existing !== null) {
+                $existing->application_status = 'Applied';
+                $existing->application_date = $now;
+                $existing->updated_at = $now;
+                $existing->resume_url = $input['resume_url'] ?? $existing->resume_url;
+                $existing->cover_letter = $input['cover_letter'] ?? $existing->cover_letter;
+                $existing->notes = $input['notes'] ?? $existing->notes;
+                $existing->save();
+
+                $applicationId = (int) $existing->getKey();
+                Capsule::table('application_answers')
+                    ->where('application_id', $applicationId)
+                    ->delete();
+                $reapplied = true;
+            } else {
+                $application = Application::create([
+                    'candidate_id' => $candidateId,
+                    'job_posting_id' => $jobId,
+                    'application_status' => 'Applied',
+                    'application_date' => $now,
+                    'resume_url' => $input['resume_url'] ?? null,
+                    'cover_letter' => $input['cover_letter'] ?? null,
+                    'notes' => $input['notes'] ?? null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+                $applicationId = (int) $application->getKey();
+            }
+
+            self::storeAnswers($applicationId, $answers, $now);
+
+            return [
+                'application_id' => $applicationId,
+                'errors' => [],
+                'reapplied' => $reapplied,
+            ];
+        });
+    }
+
+    public function listApplications(array $filters = []): array
+    {
+        $query = Application::query()->with(['candidate', 'jobPosting']);
+
+        if (isset($filters['job_id']) && (int) $filters['job_id'] > 0) {
+            $query->where('job_posting_id', (int) $filters['job_id']);
+        }
+
+        if (isset($filters['candidate_id']) && (int) $filters['candidate_id'] > 0) {
+            $query->where('candidate_id', (int) $filters['candidate_id']);
+        }
+
+        $applications = $query->orderByDesc('application_date')->get();
+
+        return $applications->map(static function (Application $application): array {
+            return self::applicationToArray($application, true, true);
+        })->all();
+    }
+
+    public function getApplication(int $applicationId): ?array
+    {
+        $application = Application::query()->with(['candidate', 'jobPosting'])->find($applicationId);
+        if ($application === null) {
+            return null;
+        }
+
+        return self::applicationToArray($application, true, true);
+    }
+
+    public function listForJob(int $jobId): array
+    {
+        if ($jobId <= 0) {
+            return [];
+        }
+
+        $applications = Application::query()
+            ->where('job_posting_id', $jobId)
+            ->with('candidate')
+            ->orderByDesc('application_date')
+            ->get();
+
+        return $applications->map(static function (Application $application): array {
+            return self::applicationToArray($application, true, false);
+        })->all();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $answers
+     */
+    private static function storeAnswers(int $applicationId, array $answers, string $timestamp): void
+    {
+        if ($answers === []) {
+            return;
+        }
+
+        $rows = [];
+        foreach ($answers as $answer) {
+            if (!is_array($answer)) {
+                continue;
+            }
+
+            $questionId = 0;
+            if (isset($answer['question_id'])) {
+                $questionId = (int) $answer['question_id'];
+            } elseif (isset($answer['qid'])) {
+                $questionId = (int) $answer['qid'];
+            }
+
+            $text = trim((string)($answer['answer'] ?? $answer['text'] ?? ''));
+            if ($questionId <= 0 || $text === '') {
+                continue;
+            }
+
+            $rows[] = [
+                'application_id' => $applicationId,
+                'question_id' => $questionId,
+                'answer_text' => $text,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ];
+        }
+
+        if ($rows !== []) {
+            Capsule::table('application_answers')->insert($rows);
+        }
+    }
+
+    private static function applicationToArray(Application $application, bool $includeCandidate, bool $includeJob): array
+    {
+        $data = $application->toArray();
+
+        if ($includeCandidate) {
+            $candidate = $application->candidate;
+            if ($candidate instanceof Model) {
+                $data['candidate'] = $candidate->toArray();
+            }
+        }
+
+        if ($includeJob) {
+            $job = $application->jobPosting;
+            if ($job instanceof Model) {
+                $data['job'] = $job->toArray();
+            }
+        }
+
+        return $data;
+    }
+}

--- a/app/Services/Job/JobAuthorizationService.php
+++ b/app/Services/Job/JobAuthorizationService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Services\Job\Contracts\JobAuthorizerInterface;
+use RuntimeException;
+
+final class JobAuthorizationService implements JobAuthorizerInterface
+{
+    public function authorizePublish(string $role, int $userId, array $jobData): void
+    {
+        if (!in_array($role, ['Employer', 'Recruiter'], true)) {
+            throw new RuntimeException('Not authorized to publish jobs.');
+        }
+
+        $companyId = (int)($jobData['company_id'] ?? 0);
+        if ($companyId <= 0) {
+            throw new RuntimeException('A company must be specified for the job posting.');
+        }
+
+        if ($role === 'Employer' && $companyId !== $userId) {
+            throw new RuntimeException('Employers may only publish jobs for their own company.');
+        }
+
+        if ($role === 'Recruiter') {
+            $recruiterId = (int)($jobData['recruiter_id'] ?? 0);
+            if ($recruiterId !== $userId) {
+                throw new RuntimeException('Recruiter context mismatch.');
+            }
+        }
+    }
+
+    public function authorizeUpdate(int $jobId, string $role, int $userId, array $jobData): void
+    {
+        $this->authorizePublish($role, $userId, $jobData);
+        if ($jobId <= 0) {
+            throw new RuntimeException('Invalid job identifier.');
+        }
+    }
+
+    public function authorizeApplication(int $jobId, int $candidateId): void
+    {
+        if ($jobId <= 0) {
+            throw new RuntimeException('Invalid job identifier.');
+        }
+        if ($candidateId <= 0) {
+            throw new RuntimeException('Authentication required.');
+        }
+    }
+}

--- a/app/Services/Job/JobInputValidator.php
+++ b/app/Services/Job/JobInputValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Services\Job\Contracts\JobValidatorInterface;
+
+final class JobInputValidator implements JobValidatorInterface
+{
+    public function validateForPublish(string $role, int $userId, array $input): array
+    {
+        $title   = trim((string)($input['job_title'] ?? ''));
+        $desc    = trim((string)($input['job_description'] ?? ''));
+        $loc     = trim((string)($input['job_location'] ?? ''));
+        $langs   = trim((string)($input['job_languages'] ?? ''));
+        $salary  = (string)($input['salary'] ?? '');
+        $empType = trim((string)($input['employment_type'] ?? 'Full-time'));
+
+        $companyId = ($role === 'Employer')
+            ? $userId
+            : (int)($input['company_id'] ?? 0);
+
+        $chosen = array_values(array_filter((array)($input['mi_questions'] ?? []), static fn($v) => ctype_digit((string) $v)));
+        $chosen = array_unique(array_map('intval', $chosen));
+
+        $errors = [];
+        if ($title === '') {
+            $errors['job_title'] = 'Job title is required.';
+        }
+        if ($desc === '') {
+            $errors['job_description'] = 'Description is required.';
+        }
+        if ($salary !== '' && !is_numeric($salary)) {
+            $errors['salary'] = 'Salary must be numeric (e.g., 3500).';
+        }
+        if ($role === 'Recruiter' && $companyId <= 0) {
+            $errors['company_id'] = 'Please select a company.';
+        }
+        if (count($chosen) !== 3) {
+            $errors['mi_questions'] = 'Please select exactly 3 questions.';
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $data = [
+            'company_id'       => $companyId,
+            'recruiter_id'     => ($role === 'Recruiter' ? $userId : null),
+            'job_title'        => $title,
+            'job_description'  => $desc,
+            'job_requirements' => null,
+            'job_location'     => $loc ?: null,
+            'job_languages'    => $langs ?: null,
+            'employment_type'  => $empType ?: 'Full-time',
+            'salary_range_min' => ($salary === '' ? null : number_format((float) $salary, 2, '.', '')),
+            'date_posted'      => $now,
+            'created_at'       => $now,
+            'updated_at'       => $now,
+            'question_ids'     => $chosen,
+        ];
+
+        return ['data' => $data, 'errors' => $errors];
+    }
+
+    public function validateForUpdate(string $role, int $userId, array $input, array $existing = []): array
+    {
+        $result = $this->validateForPublish($role, $userId, $input);
+
+        // Preserve existing timestamps if provided to avoid overwriting unintentionally.
+        if (isset($existing['created_at'])) {
+            $result['data']['created_at'] = $existing['created_at'];
+        }
+
+        return $result;
+    }
+}

--- a/app/Services/Job/JobModuleFacade.php
+++ b/app/Services/Job/JobModuleFacade.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Services\Job\Contracts\JobAnalyticsInterface;
+use App\Services\Job\Contracts\JobApplicationManagerInterface;
+use App\Services\Job\Contracts\JobAuthorizerInterface;
+use App\Services\Job\Contracts\JobNotifierInterface;
+use App\Services\Job\Contracts\JobRepositoryInterface;
+use App\Services\Job\Contracts\JobSearchInterface;
+use App\Services\Job\Contracts\JobValidatorInterface;
+use InvalidArgumentException;
+use Throwable;
+
+final class JobModuleFacade
+{
+    public function __construct(
+        private readonly JobValidatorInterface $validator,
+        private readonly JobAuthorizerInterface $authorizer,
+        private readonly JobRepositoryInterface $repository,
+        private readonly JobNotifierInterface $notifier,
+        private readonly JobSearchInterface $search,
+        private readonly JobAnalyticsInterface $analytics,
+        private readonly JobApplicationManagerInterface $applications
+    ) {
+    }
+
+    public static function buildDefault(): self
+    {
+        return new self(
+            new JobInputValidator(),
+            new JobAuthorizationService(),
+            new JobRepository(),
+            new JobNotificationService(),
+            new JobSearchService(),
+            new JobAnalyticsService(),
+            new JobApplicationWorkflow()
+        );
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: array<string, string>}
+     */
+    public function validateJobInput(string $role, int $userId, array $input): array
+    {
+        $result = $this->validator->validateForPublish($role, $userId, $input);
+
+        return [$result['data'], $result['errors']];
+    }
+
+    /**
+     * @return array{0:int,1:array<string,string>}
+     */
+    public function publishJob(string $role, int $userId, array $input): array
+    {
+        [$data, $errors] = $this->validateJobInput($role, $userId, $input);
+        if ($errors !== []) {
+            return [0, $errors];
+        }
+
+        try {
+            $this->authorizer->authorizePublish($role, $userId, $data);
+        } catch (Throwable $e) {
+            return [0, ['general' => $e->getMessage()]];
+        }
+
+        $questionIds = $data['question_ids'] ?? [];
+        unset($data['question_ids']);
+
+        try {
+            $jobId = $this->repository->createJob($data, $questionIds);
+        } catch (Throwable) {
+            return [0, ['general' => 'Could not create job.']];
+        }
+
+        $this->notifier->jobPublished($jobId, $data);
+        $this->search->refreshJob($jobId);
+        $this->analytics->recordJobPublished($jobId, $data);
+
+        return [$jobId, []];
+    }
+
+    /**
+     * @return array{0:bool,1:array<string,string>}
+     */
+    public function updateJob(int $jobId, string $role, int $userId, array $input, array $existing = []): array
+    {
+        $result = $this->validator->validateForUpdate($role, $userId, $input, $existing);
+        $data = $result['data'];
+        $errors = $result['errors'];
+
+        if ($errors !== []) {
+            return [false, $errors];
+        }
+
+        try {
+            $this->authorizer->authorizeUpdate($jobId, $role, $userId, $data);
+        } catch (Throwable $e) {
+            return [false, ['general' => $e->getMessage()]];
+        }
+
+        $questionIds = $data['question_ids'] ?? [];
+        unset($data['question_ids']);
+
+        try {
+            $updated = $this->repository->updateJob($jobId, $data, $questionIds);
+        } catch (Throwable) {
+            return [false, ['general' => 'Could not update job.']];
+        }
+
+        if (!$updated) {
+            return [false, ['general' => 'Job not found.']];
+        }
+
+        $this->notifier->jobUpdated($jobId, $data);
+        $this->search->refreshJob($jobId);
+        $this->analytics->recordJobUpdated($jobId, $data);
+
+        return [true, []];
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     *
+     * @return array{jobs: array<int, array<string, mixed>>, count: int, filters: array<string, mixed|null>}
+     */
+    public function listJobs(array $filters = []): array
+    {
+        $normalised = $this->normaliseJobFilters($filters);
+        $jobs = $this->search->search($normalised);
+
+        return [
+            'jobs' => $jobs,
+            'count' => count($jobs),
+            'filters' => [
+                'status' => $normalised['status'] ?? null,
+                'company_id' => $normalised['company_id'] ?? null,
+                'recruiter_id' => $normalised['recruiter_id'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function showJob(int $jobId): array
+    {
+        $job = $this->search->getJob($jobId);
+        if ($job === null) {
+            throw new InvalidArgumentException('Job posting not found.');
+        }
+
+        $applications = $this->applications->listForJob($jobId);
+        $job['applications'] = $applications;
+        $job['application_count'] = count($applications);
+
+        return ['job' => $job];
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @return array{applications: array<int, array<string, mixed>>, count: int}
+     */
+    public function listApplications(array $filters = []): array
+    {
+        $applications = $this->applications->listApplications($filters);
+
+        return [
+            'applications' => $applications,
+            'count' => count($applications),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function showApplication(int $applicationId, ?callable $candidateProfileResolver = null): array
+    {
+        $application = $this->applications->getApplication($applicationId);
+        if ($application === null) {
+            throw new InvalidArgumentException('Application record not found.');
+        }
+
+        if ($candidateProfileResolver !== null && isset($application['candidate']['candidate_id'])) {
+            $candidateId = (int) $application['candidate']['candidate_id'];
+            if ($candidateId > 0) {
+                $application['profile'] = $candidateProfileResolver($candidateId);
+            }
+        }
+
+        return ['application' => $application];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summarise(?callable $candidateProfileResolver = null): array
+    {
+        return $this->analytics->summarise($candidateProfileResolver);
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    public function applyToJob(int $jobId, int $candidateId, array $input): array
+    {
+        try {
+            $this->authorizer->authorizeApplication($jobId, $candidateId);
+        } catch (Throwable $e) {
+            return ['application_id' => 0, 'errors' => ['general' => $e->getMessage()]];
+        }
+
+        $result = $this->applications->applyToJob($jobId, $candidateId, $input);
+        $applicationId = (int) ($result['application_id'] ?? 0);
+        $errors = $result['errors'] ?? [];
+
+        if ($errors === [] && $applicationId > 0) {
+            $this->notifier->applicationSubmitted($applicationId);
+        }
+
+        $result['application_id'] = $applicationId;
+        $result['errors'] = $errors;
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @return array<string, mixed>
+     */
+    private function normaliseJobFilters(array $filters): array
+    {
+        $normalised = [];
+
+        if (isset($filters['status']) && $filters['status'] !== '') {
+            $normalised['status'] = $filters['status'];
+        }
+
+        if (isset($filters['company_id']) && (int) $filters['company_id'] > 0) {
+            $normalised['company_id'] = (int) $filters['company_id'];
+        }
+
+        if (isset($filters['recruiter_id']) && (int) $filters['recruiter_id'] > 0) {
+            $normalised['recruiter_id'] = (int) $filters['recruiter_id'];
+        }
+
+        if (isset($filters['scope']) && is_string($filters['scope'])) {
+            $this->applyScopeFilter($normalised, $filters['scope']);
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    private function applyScopeFilter(array &$filters, string $scope): void
+    {
+        $scope = trim(strtolower($scope));
+        if ($scope === '') {
+            return;
+        }
+
+        if (in_array($scope, ['active', 'open'], true)) {
+            $filters['status'] = $filters['status'] ?? 'active';
+            return;
+        }
+
+        if (in_array($scope, ['closed', 'archived'], true)) {
+            $filters['status'] = $filters['status'] ?? 'closed';
+            return;
+        }
+
+        if (str_starts_with($scope, 'employer-')) {
+            $companyId = substr($scope, strlen('employer-'));
+            if (ctype_digit($companyId)) {
+                $filters['company_id'] = (int) $companyId;
+            }
+            return;
+        }
+
+        if (str_starts_with($scope, 'recruiter-')) {
+            $recruiterId = substr($scope, strlen('recruiter-'));
+            if (ctype_digit($recruiterId)) {
+                $filters['recruiter_id'] = (int) $recruiterId;
+            }
+        }
+    }
+}

--- a/app/Services/Job/JobNotificationService.php
+++ b/app/Services/Job/JobNotificationService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Services\Job\Contracts\JobNotifierInterface;
+use App\Services\Notify;
+
+final class JobNotificationService implements JobNotifierInterface
+{
+    public function jobPublished(int $jobId, array $jobData): void
+    {
+        // No dedicated notification for job publication yet.
+    }
+
+    public function jobUpdated(int $jobId, array $jobData): void
+    {
+        // Placeholder for future job update notifications.
+    }
+
+    public function applicationSubmitted(int $applicationId): void
+    {
+        Notify::onApplicationCreated($applicationId);
+    }
+}

--- a/app/Services/Job/JobRepository.php
+++ b/app/Services/Job/JobRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Models\JobPosting;
+use App\Services\Job\Contracts\JobRepositoryInterface;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+final class JobRepository implements JobRepositoryInterface
+{
+    public function createJob(array $data, array $questionIds = []): int
+    {
+        return Capsule::connection()->transaction(static function () use ($data, $questionIds) {
+            $job = JobPosting::create($data);
+            $jobId = (int) $job->getKey();
+            JobPosting::attachQuestions($jobId, $questionIds);
+
+            return $jobId;
+        });
+    }
+
+    public function updateJob(int $jobId, array $data, array $questionIds = []): bool
+    {
+        return Capsule::connection()->transaction(static function () use ($jobId, $data, $questionIds) {
+            $job = JobPosting::query()->find($jobId);
+            if ($job === null) {
+                return false;
+            }
+
+            $job->fill($data);
+            $job->save();
+
+            Capsule::table('job_micro_questions')
+                ->where('job_posting_id', $jobId)
+                ->delete();
+            JobPosting::attachQuestions($jobId, $questionIds);
+
+            return true;
+        });
+    }
+}

--- a/app/Services/Job/JobSearchService.php
+++ b/app/Services/Job/JobSearchService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Job;
+
+use App\Models\JobPosting;
+use App\Services\Job\Contracts\JobSearchInterface;
+use Illuminate\Database\Eloquent\Model;
+
+final class JobSearchService implements JobSearchInterface
+{
+    public function refreshJob(int $jobId): void
+    {
+        // Search index is not implemented; method included for interface completeness.
+    }
+
+    public function search(array $filters = []): array
+    {
+        $query = JobPosting::query()->with(['employer', 'recruiter']);
+
+        if (isset($filters['status']) && $filters['status'] !== '') {
+            $query->where('status', $filters['status']);
+        }
+
+        if (isset($filters['company_id']) && (int) $filters['company_id'] > 0) {
+            $query->where('company_id', (int) $filters['company_id']);
+        }
+
+        if (isset($filters['recruiter_id']) && (int) $filters['recruiter_id'] > 0) {
+            $query->where('recruiter_id', (int) $filters['recruiter_id']);
+        }
+
+        $jobs = $query->orderByDesc('date_posted')->get();
+
+        return $jobs->map(static function (JobPosting $posting): array {
+            $data = $posting->toArray();
+            $employer = $posting->employer;
+            if ($employer instanceof Model) {
+                $data['employer'] = $employer->toArray();
+            }
+            $recruiter = $posting->recruiter;
+            if ($recruiter instanceof Model) {
+                $data['recruiter'] = $recruiter->toArray();
+            }
+
+            return $data;
+        })->all();
+    }
+
+    public function getJob(int $jobId): ?array
+    {
+        $job = JobPosting::query()->with(['employer', 'recruiter'])->find($jobId);
+        if ($job === null) {
+            return null;
+        }
+
+        $data = $job->toArray();
+        $employer = $job->employer;
+        if ($employer instanceof Model) {
+            $data['employer'] = $employer->toArray();
+        }
+        $recruiter = $job->recruiter;
+        if ($recruiter instanceof Model) {
+            $data['recruiter'] = $recruiter->toArray();
+        }
+
+        return $data;
+    }
+}

--- a/app/Services/JobService.php
+++ b/app/Services/JobService.php
@@ -4,90 +4,33 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Models\JobPosting;
-use Illuminate\Database\Capsule\Manager as Capsule;
+use App\Services\Job\JobModuleFacade;
 
 /**
- * Service layer responsible for job posting business rules.
+ * Backwards-compatible wrapper that delegates job orchestration to the module facade.
  */
 final class JobService
 {
-    /**
-     * Validate input and create a new job posting.
-     *
-     * @param string $role   Authenticated user role (Employer or Recruiter)
-     * @param int    $userId Authenticated user ID
-     * @param array  $input  Raw request payload
-     *
-     * @return array{0:int,1:array} [jobId, errors]
-     */
-    public function create(string $role, int $userId, array $input): array
+    private JobModuleFacade $facade;
+
+    public function __construct(?JobModuleFacade $facade = null)
     {
-        [$data, $errors] = $this->validate($role, $userId, $input);
-        if ($errors) {
-            return [0, $errors];
-        }
-
-        $questionIds = $data['question_ids'];
-        unset($data['question_ids']);
-
-        try {
-            $jobId = Capsule::connection()->transaction(function () use ($data, $questionIds) {
-                $job = JobPosting::create($data);
-                JobPosting::attachQuestions((int)$job->getKey(), $questionIds);
-                return (int)$job->getKey();
-            });
-            return [$jobId, []];
-        } catch (\Throwable $e) {
-            return [0, ['general' => 'Could not create job.']];
-        }
+        $this->facade = $facade ?? JobModuleFacade::buildDefault();
     }
 
     /**
-     * Validate and normalise job input data.
-     *
-     * @return array{0:array,1:array} [normalised data, errors]
+     * @return array{0:int,1:array<string,string>}
+     */
+    public function create(string $role, int $userId, array $input): array
+    {
+        return $this->facade->publishJob($role, $userId, $input);
+    }
+
+    /**
+     * @return array{0:array<string, mixed>,1:array<string,string>}
      */
     public function validate(string $role, int $userId, array $input): array
     {
-        $title   = trim((string)($input['job_title'] ?? ''));
-        $desc    = trim((string)($input['job_description'] ?? ''));
-        $loc     = trim((string)($input['job_location'] ?? ''));
-        $langs   = trim((string)($input['job_languages'] ?? ''));
-        $salary  = (string)($input['salary'] ?? '');
-        $empType = trim((string)($input['employment_type'] ?? 'Full-time'));
-
-        $companyId = ($role === 'Employer')
-            ? $userId
-            : (int)($input['company_id'] ?? 0);
-
-        $chosen = array_values(array_filter((array)($input['mi_questions'] ?? []), fn($v) => ctype_digit((string)$v)));
-        $chosen = array_unique(array_map('intval', $chosen));
-
-        $errors = [];
-        if ($title === '') $errors['job_title'] = 'Job title is required.';
-        if ($desc  === '') $errors['job_description'] = 'Description is required.';
-        if ($salary !== '' && !is_numeric($salary)) $errors['salary'] = 'Salary must be numeric (e.g., 3500).';
-        if ($role === 'Recruiter' && $companyId <= 0) $errors['company_id'] = 'Please select a company.';
-        if (count($chosen) !== 3) $errors['mi_questions'] = 'Please select exactly 3 questions.';
-
-        $now = date('Y-m-d H:i:s');
-        $data = [
-            'company_id'      => $companyId,
-            'recruiter_id'    => ($role === 'Recruiter' ? $userId : null),
-            'job_title'       => $title,
-            'job_description' => $desc,
-            'job_requirements'=> null,
-            'job_location'    => $loc ?: null,
-            'job_languages'   => $langs ?: null,
-            'employment_type' => $empType ?: 'Full-time',
-            'salary_range_min'=> ($salary === '' ? null : number_format((float)$salary, 2, '.', '')),
-            'date_posted'     => $now,
-            'created_at'      => $now,
-            'updated_at'      => $now,
-            'question_ids'    => $chosen,
-        ];
-
-        return [$data, $errors];
+        return $this->facade->validateJobInput($role, $userId, $input);
     }
 }

--- a/app/Services/Modules/JobApplicationService.php
+++ b/app/Services/Modules/JobApplicationService.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace App\Services\Modules;
 
 use App\Core\Request;
-use App\Models\Application;
-use App\Models\JobPosting;
-use Illuminate\Database\Eloquent\Model;
+use App\Services\Job\JobModuleFacade;
 use InvalidArgumentException;
 
 final class JobApplicationService extends AbstractModuleService
 {
+    private JobModuleFacade $facade;
+
+    public function __construct(?JobModuleFacade $facade = null)
+    {
+        $this->facade = $facade ?? JobModuleFacade::buildDefault();
+    }
+
     public function name(): string
     {
         return 'job-application';
@@ -34,68 +39,26 @@ final class JobApplicationService extends AbstractModuleService
      */
     private function listJobs(Request $request, ?string $scope): array
     {
-        $query = JobPosting::query()->with(['employer', 'recruiter']);
-
-        $status = $this->query($request, 'status');
-        if ($scope !== null && $scope !== '' && !ctype_digit($scope)) {
-            $scopeLower = strtolower($scope);
-            if (in_array($scopeLower, ['active', 'open'], true)) {
-                $status = $status ?? 'active';
-            } elseif (in_array($scopeLower, ['closed', 'archived'], true)) {
-                $status = $status ?? 'closed';
-            }
-        }
-
-        if ($status !== null && $status !== '') {
-            $query->where('status', $status);
-        }
-
-        if ($scope !== null && str_starts_with($scope, 'employer-')) {
-            $companyId = substr($scope, strlen('employer-'));
-            if (ctype_digit($companyId)) {
-                $query->where('company_id', (int) $companyId);
-            }
-        } elseif ($scope !== null && str_starts_with($scope, 'recruiter-')) {
-            $recruiterId = substr($scope, strlen('recruiter-'));
-            if (ctype_digit($recruiterId)) {
-                $query->where('recruiter_id', (int) $recruiterId);
-            }
-        }
+        $filters = [
+            'status' => $this->query($request, 'status'),
+            'scope' => $scope,
+        ];
 
         if ($employer = $this->query($request, 'employer_id')) {
             if (ctype_digit($employer)) {
-                $query->where('company_id', (int) $employer);
+                $filters['company_id'] = (int) $employer;
             }
         }
 
         if ($recruiter = $this->query($request, 'recruiter_id')) {
             if (ctype_digit($recruiter)) {
-                $query->where('recruiter_id', (int) $recruiter);
+                $filters['recruiter_id'] = (int) $recruiter;
             }
         }
 
-        $jobs = $query->orderByDesc('date_posted')->get();
+        $result = $this->facade->listJobs($filters);
 
-        $items = $jobs->map(static function (JobPosting $posting): array {
-            $data = $posting->toArray();
-            $employer = $posting->employer;
-            if ($employer instanceof Model) {
-                $data['employer'] = $employer->toArray();
-            }
-            $recruiter = $posting->recruiter;
-            if ($recruiter instanceof Model) {
-                $data['recruiter'] = $recruiter->toArray();
-            }
-            return $data;
-        })->all();
-
-        return $this->respond([
-            'jobs' => $items,
-            'count' => count($items),
-            'filters' => [
-                'status' => $status,
-            ],
-        ]);
+        return $this->respond($result);
     }
 
     /**
@@ -104,39 +67,8 @@ final class JobApplicationService extends AbstractModuleService
     private function showJob(?string $id): array
     {
         $jobId = $this->requireIntId($id, 'A job identifier is required.');
-        $job = JobPosting::query()->with(['employer', 'recruiter'])->find($jobId);
-        if ($job === null) {
-            throw new InvalidArgumentException('Job posting not found.');
-        }
 
-        $payload = $job->toArray();
-        $employer = $job->employer;
-        if ($employer instanceof Model) {
-            $payload['employer'] = $employer->toArray();
-        }
-        $recruiter = $job->recruiter;
-        if ($recruiter instanceof Model) {
-            $payload['recruiter'] = $recruiter->toArray();
-        }
-
-        $applications = Application::query()
-            ->where('job_posting_id', $jobId)
-            ->with('candidate')
-            ->get();
-
-        $payload['applications'] = $applications->map(static function (Application $application): array {
-            $data = $application->toArray();
-            $candidate = $application->candidate;
-            if ($candidate instanceof Model) {
-                $data['candidate'] = $candidate->toArray();
-            }
-            return $data;
-        })->all();
-        $payload['application_count'] = $applications->count();
-
-        return $this->respond([
-            'job' => $payload,
-        ]);
+        return $this->respond($this->facade->showJob($jobId));
     }
 
     /**
@@ -144,39 +76,23 @@ final class JobApplicationService extends AbstractModuleService
      */
     private function listApplications(Request $request): array
     {
-        $query = Application::query()->with(['candidate', 'jobPosting']);
+        $filters = [];
 
         if ($job = $this->query($request, 'job_id')) {
             if (ctype_digit($job)) {
-                $query->where('job_posting_id', (int) $job);
+                $filters['job_id'] = (int) $job;
             }
         }
 
         if ($candidate = $this->query($request, 'candidate_id')) {
             if (ctype_digit($candidate)) {
-                $query->where('candidate_id', (int) $candidate);
+                $filters['candidate_id'] = (int) $candidate;
             }
         }
 
-        $applications = $query->orderByDesc('application_date')->get();
+        $result = $this->facade->listApplications($filters);
 
-        $items = $applications->map(static function (Application $application): array {
-            $data = $application->toArray();
-            $candidate = $application->candidate;
-            if ($candidate instanceof Model) {
-                $data['candidate'] = $candidate->toArray();
-            }
-            $jobPosting = $application->jobPosting;
-            if ($jobPosting instanceof Model) {
-                $data['job'] = $jobPosting->toArray();
-            }
-            return $data;
-        })->all();
-
-        return $this->respond([
-            'applications' => $items,
-            'count' => count($items),
-        ]);
+        return $this->respond($result);
     }
 
     /**
@@ -185,29 +101,13 @@ final class JobApplicationService extends AbstractModuleService
     private function showApplication(?string $id): array
     {
         $applicationId = $this->requireIntId($id, 'An application identifier is required.');
-        $application = Application::query()->with(['candidate', 'jobPosting'])->find($applicationId);
-        if ($application === null) {
-            throw new InvalidArgumentException('Application record not found.');
-        }
 
-        $payload = $application->toArray();
-        $candidate = $application->candidate;
-        if ($candidate instanceof Model) {
-            $payload['candidate'] = $candidate->toArray();
-        }
-        $jobPosting = $application->jobPosting;
-        if ($jobPosting instanceof Model) {
-            $payload['job'] = $jobPosting->toArray();
-        }
+        $result = $this->facade->showApplication(
+            $applicationId,
+            fn (int $candidateId) => $this->forward('resume-profile', 'profile', (string) $candidateId)
+        );
 
-        if (isset($payload['candidate']['candidate_id'])) {
-            $candidateId = (string) $payload['candidate']['candidate_id'];
-            $payload['profile'] = $this->forward('resume-profile', 'profile', $candidateId);
-        }
-
-        return $this->respond([
-            'application' => $payload,
-        ]);
+        return $this->respond($result);
     }
 
     /**
@@ -215,48 +115,10 @@ final class JobApplicationService extends AbstractModuleService
      */
     private function summarise(): array
     {
-        $totalJobs = JobPosting::query()->count();
-        $activeJobs = JobPosting::query()->whereIn('status', ['active', 'open'])->count();
-        $closedJobs = JobPosting::query()->whereIn('status', ['closed', 'archived'])->count();
+        $result = $this->facade->summarise(
+            fn (int $candidateId) => $this->forward('resume-profile', 'profile', (string) $candidateId)
+        );
 
-        $totalApplications = Application::query()->count();
-        $recentApplications = Application::query()->orderByDesc('application_date')->take(5)->get();
-        $recent = $recentApplications->map(static function (Application $application): array {
-            return $application->toArray();
-        })->all();
-
-        $topCandidates = Application::query()
-            ->selectRaw('candidate_id, COUNT(*) as total_applications')
-            ->whereNotNull('candidate_id')
-            ->groupBy('candidate_id')
-            ->orderByDesc('total_applications')
-            ->take(5)
-            ->get()
-            ->map(function ($row) {
-                $candidateId = (string) $row->candidate_id;
-                $profile = $this->forward('resume-profile', 'profile', $candidateId);
-                return [
-                    'candidate_id' => (int) $row->candidate_id,
-                    'applications' => (int) $row->total_applications,
-                    'profile' => $profile['profile'] ?? null,
-                    'resume' => $profile['resume'] ?? null,
-                ];
-            })
-            ->all();
-
-        return $this->respond([
-            'summary' => [
-                'jobs' => [
-                    'total' => $totalJobs,
-                    'active' => $activeJobs,
-                    'closed' => $closedJobs,
-                ],
-                'applications' => [
-                    'total' => $totalApplications,
-                    'recent' => $recent,
-                ],
-                'top_candidates' => $topCandidates,
-            ],
-        ]);
+        return $this->respond($result);
     }
 }

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Core\Container;
 use App\Core\DB;
 use App\Core\Middleware;
+use App\Services\Job\JobModuleFacade;
 use Illuminate\Database\Capsule\Manager as Capsule;
 
 // Base directory of the project
@@ -157,6 +158,7 @@ $container = new Container();
 $container->set('config', $config);
 $container->set('db', DB::conn());
 $container->set('orm', $capsule);
+$container->singleton(JobModuleFacade::class, static fn (): JobModuleFacade => JobModuleFacade::buildDefault());
 
 // Shared middleware registry (none yet but ready for expansion)
 Middleware::run();

--- a/tests/Services/Job/JobModuleFacadeTest.php
+++ b/tests/Services/Job/JobModuleFacadeTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../../../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+use App\Services\Job\Contracts\JobAnalyticsInterface;
+use App\Services\Job\Contracts\JobApplicationManagerInterface;
+use App\Services\Job\Contracts\JobAuthorizerInterface;
+use App\Services\Job\Contracts\JobNotifierInterface;
+use App\Services\Job\Contracts\JobRepositoryInterface;
+use App\Services\Job\Contracts\JobSearchInterface;
+use App\Services\Job\Contracts\JobValidatorInterface;
+use App\Services\Job\JobModuleFacade;
+
+final class StubValidator implements JobValidatorInterface
+{
+    public array $publishCalls = [];
+
+    public function validateForPublish(string $role, int $userId, array $input): array
+    {
+        $this->publishCalls[] = [$role, $userId, $input];
+
+        return [
+            'data' => [
+                'company_id' => $userId,
+                'recruiter_id' => ($role === 'Recruiter' ? $userId : null),
+                'question_ids' => [1, 2, 3],
+            ],
+            'errors' => [],
+        ];
+    }
+
+    public function validateForUpdate(string $role, int $userId, array $input, array $existing = []): array
+    {
+        return $this->validateForPublish($role, $userId, $input);
+    }
+}
+
+final class StubAuthorizer implements JobAuthorizerInterface
+{
+    public array $publishCalls = [];
+    public array $updateCalls = [];
+    public array $applicationCalls = [];
+
+    public function authorizePublish(string $role, int $userId, array $jobData): void
+    {
+        $this->publishCalls[] = [$role, $userId, $jobData];
+    }
+
+    public function authorizeUpdate(int $jobId, string $role, int $userId, array $jobData): void
+    {
+        $this->updateCalls[] = [$jobId, $role, $userId, $jobData];
+    }
+
+    public function authorizeApplication(int $jobId, int $candidateId): void
+    {
+        $this->applicationCalls[] = [$jobId, $candidateId];
+    }
+}
+
+final class StubRepository implements JobRepositoryInterface
+{
+    public array $createCalls = [];
+    public array $updateCalls = [];
+    public int $nextJobId = 99;
+
+    public function createJob(array $data, array $questionIds = []): int
+    {
+        $this->createCalls[] = [$data, $questionIds];
+        return $this->nextJobId;
+    }
+
+    public function updateJob(int $jobId, array $data, array $questionIds = []): bool
+    {
+        $this->updateCalls[] = [$jobId, $data, $questionIds];
+        return true;
+    }
+}
+
+final class StubNotifier implements JobNotifierInterface
+{
+    public array $jobPublished = [];
+    public array $jobUpdated = [];
+    public array $applicationSubmitted = [];
+
+    public function jobPublished(int $jobId, array $jobData): void
+    {
+        $this->jobPublished[] = [$jobId, $jobData];
+    }
+
+    public function jobUpdated(int $jobId, array $jobData): void
+    {
+        $this->jobUpdated[] = [$jobId, $jobData];
+    }
+
+    public function applicationSubmitted(int $applicationId): void
+    {
+        $this->applicationSubmitted[] = $applicationId;
+    }
+}
+
+final class StubSearch implements JobSearchInterface
+{
+    public array $refreshCalls = [];
+
+    public function refreshJob(int $jobId): void
+    {
+        $this->refreshCalls[] = $jobId;
+    }
+
+    public function search(array $filters = []): array
+    {
+        return [];
+    }
+
+    public function getJob(int $jobId): ?array
+    {
+        return null;
+    }
+}
+
+final class StubAnalytics implements JobAnalyticsInterface
+{
+    public array $published = [];
+
+    public function recordJobPublished(int $jobId, array $jobData): void
+    {
+        $this->published[] = ['published', $jobId, $jobData];
+    }
+
+    public function recordJobUpdated(int $jobId, array $jobData): void
+    {
+        $this->published[] = ['updated', $jobId, $jobData];
+    }
+
+    public function summarise(?callable $candidateProfileResolver = null): array
+    {
+        return ['summary' => []];
+    }
+}
+
+final class StubApplications implements JobApplicationManagerInterface
+{
+    public array $applyCalls = [];
+    public array $listCalls = [];
+    public array $getCalls = [];
+    public array $nextApplyResult = ['application_id' => 42, 'errors' => []];
+
+    public function applyToJob(int $jobId, int $candidateId, array $input): array
+    {
+        $this->applyCalls[] = [$jobId, $candidateId, $input];
+        return $this->nextApplyResult;
+    }
+
+    public function listApplications(array $filters = []): array
+    {
+        $this->listCalls[] = $filters;
+        return [];
+    }
+
+    public function getApplication(int $applicationId): ?array
+    {
+        $this->getCalls[] = $applicationId;
+        return null;
+    }
+
+    public function listForJob(int $jobId): array
+    {
+        return [];
+    }
+}
+
+// --- publish job triggers ---
+$validator = new StubValidator();
+$authorizer = new StubAuthorizer();
+$repository = new StubRepository();
+$notifier = new StubNotifier();
+$search = new StubSearch();
+$analytics = new StubAnalytics();
+$applications = new StubApplications();
+
+$facade = new JobModuleFacade($validator, $authorizer, $repository, $notifier, $search, $analytics, $applications);
+
+[$jobId, $errors] = $facade->publishJob('Employer', 7, ['job_title' => 'Example']);
+
+assert($jobId === 99, 'Repository job ID should be returned.');
+assert($errors === [], 'No errors expected when publish succeeds.');
+assert(count($validator->publishCalls) === 1, 'Validator should be invoked once.');
+assert(count($authorizer->publishCalls) === 1, 'Authorizer should be invoked once.');
+assert(count($repository->createCalls) === 1, 'Repository create should be called.');
+assert($notifier->jobPublished === [[99, $repository->createCalls[0][0]]], 'Notifier should receive job data.');
+assert($search->refreshCalls === [99], 'Search refresh should be triggered.');
+assert($analytics->published[0][0] === 'published', 'Analytics publish event recorded.');
+
+// --- apply to job notifications ---
+$applications->nextApplyResult = ['application_id' => 555, 'errors' => []];
+$applyResult = $facade->applyToJob(10, 20, ['answers' => []]);
+assert($applications->applyCalls[0][0] === 10, 'Application manager should receive job ID.');
+assert($applyResult['application_id'] === 555, 'Application ID from manager should be returned.');
+assert($notifier->applicationSubmitted === [555], 'Notifier should be called on success.');
+
+// --- apply failure should not notify ---
+$applications->nextApplyResult = ['application_id' => 777, 'errors' => ['general' => 'Already applied']];
+$facade->applyToJob(10, 20, []);
+assert(count($notifier->applicationSubmitted) === 1, 'Notifier should not run when errors exist.');
+
+echo "JobModuleFacade tests passed\n";


### PR DESCRIPTION
## Summary
- add a JobModuleFacade and supporting job services to coordinate validation, authorization, persistence, notifications, search, analytics, and applications
- refactor JobService and the job module service to delegate to the facade and register it with the container
- create facade-focused tests that exercise publish and apply flows via stubbed collaborators

## Testing
- php tests/JobServiceTest.php
- php tests/Services/Job/JobModuleFacadeTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d15daf59b08328a203f7a6e89de7ef