### PR TITLE
Add payment observer notifications for lifecycle events

### DIFF
--- a/app/Services/Payment/Observers/AccountingNotifier.php
+++ b/app/Services/Payment/Observers/AccountingNotifier.php
@@ -8,7 +8,7 @@ use App\Services\Payment\PaymentEvent;
 use App\Services\Payment\PaymentObserver;
 use App\Services\Payment\PaymentProcessor;
 
-final class AccountingExporter implements PaymentObserver
+final class AccountingNotifier implements PaymentObserver
 {
     public function __construct(private readonly string $logFile)
     {
@@ -19,6 +19,7 @@ final class AccountingExporter implements PaymentObserver
         if (!in_array($event->name(), [
             PaymentProcessor::EVENT_INVOICE_PAID,
             PaymentProcessor::EVENT_PAYMENT_FAILED,
+            PaymentProcessor::EVENT_PAYMENT_REFUNDED,
         ], true)) {
             return;
         }


### PR DESCRIPTION
## Summary
- introduce a payment_refunded lifecycle event on the payment processor and wire default observers for paid, failed, and refunded transactions
- replace invoice and accounting observers with InvoiceStatusUpdater and AccountingNotifier classes that update billing records, log events, and support refunds
- enhance the subscription state manager to adjust credits and premium badges on success and refund, and expand observer tests to cover success, failure, and refund scenarios

## Testing
- php tests/Services/PaymentProcessorObserverTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d178c2165c8328a4c81eb4b2ef6039