### PR TITLE
Add API controllers and demo endpoints

### DIFF
--- a/app/Controllers/Api/AuthApiController.php
+++ b/app/Controllers/Api/AuthApiController.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use App\Core\DB;
+use App\Controllers\Auth\UserProviderFactory;
+use App\Services\AttemptService;
+
+final class AuthApiController
+{
+    private const JWT_SECRET = 'replace_this_with_a_secure_secret';
+
+    private function json($data, int $status = 200): void
+    {
+        header('Content-Type: application/json');
+        http_response_code($status);
+        echo json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    private function createJwt(array $payload): string
+    {
+        $header = ['alg' => 'HS256', 'typ' => 'JWT'];
+        $payload['iat'] = time();
+        $payload['exp'] = time() + 3600;
+        $b64 = static function ($data) {
+            return rtrim(strtr(base64_encode(json_encode($data)), '+/', '-_'), '=');
+        };
+        $headerB = $b64($header);
+        $payloadB = $b64($payload);
+        $signature = hash_hmac('sha256', "$headerB.$payloadB", self::JWT_SECRET, true);
+        $signatureB = rtrim(strtr(base64_encode($signature), '+/', '-_'), '=');
+        return "$headerB.$payloadB.$signatureB";
+    }
+
+    private function httpGet(string $url, array $headers = [], int $timeout = 5): ?array
+    {
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => $timeout,
+            CURLOPT_FAILONERROR => false,
+            CURLOPT_HTTPHEADER => $headers,
+        ]);
+        $body = curl_exec($ch);
+        $errno = curl_errno($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($errno || $body === false || $httpCode >= 500) {
+            return null;
+        }
+        $decoded = json_decode($body, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    public function login(): void
+    {
+        $input = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($input)) {
+            $input = $_POST;
+        }
+
+        $email = strtolower(trim((string)($input['email'] ?? '')));
+        $password = (string)($input['password'] ?? '');
+        $roleHint = isset($input['role']) ? trim((string)$input['role']) : null;
+
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->json(['status' => 'error', 'message' => 'Invalid email'], 400);
+        }
+        if ($password === '') {
+            $this->json(['status' => 'error', 'message' => 'Password required'], 400);
+        }
+
+        $pdo = DB::conn();
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+        $attemptSvc = new AttemptService();
+
+        if ($attemptSvc->isLockedOut($pdo, $email, $ip)) {
+            $this->json([
+                'status' => 'error',
+                'message' => 'Account temporarily locked due to multiple failed attempts.',
+            ], 429);
+        }
+
+        $found = null;
+        if ($roleHint !== null && $roleHint !== '') {
+            $provider = UserProviderFactory::providerForRole(ucfirst(strtolower($roleHint)));
+            if ($provider) {
+                $row = $provider->findByEmail($pdo, $email);
+                if ($row !== null) {
+                    $row['role'] = $provider->getRole();
+                    $found = ['provider' => $provider, 'user' => $row];
+                }
+            }
+        }
+
+        if (!$found) {
+            $found = UserProviderFactory::findByEmail($pdo, $email);
+        }
+
+        if (!$found || !password_verify($password, (string)$found['user']['password_hash'])) {
+            $attemptSvc->recordFailure($pdo, $email, $ip);
+            $left = max(0, AttemptService::MAX_ATTEMPTS - $attemptSvc->attemptCount($pdo, $email, $ip));
+            $this->json([
+                'status' => 'error',
+                'message' => 'Invalid credentials',
+                'attempts_left' => $left,
+            ], 401);
+        }
+
+        $provider = $found['provider'];
+        $user = $found['user'];
+        $meta = $provider->fetchMeta($pdo, (int)$user['id']);
+
+        $attemptSvc->resetAttempts($pdo, $email, $ip);
+
+        $payload = [
+            'sub' => (int)$user['id'],
+            'email' => (string)$user['email'],
+            'role' => (string)$user['role'],
+        ];
+        $jwt = $this->createJwt($payload);
+
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $scriptName = (string)($_SERVER['SCRIPT_NAME'] ?? '');
+        $profilePath = preg_replace('#/auth/login\.php$#', '/profile/show.php', $scriptName);
+        if ($profilePath === $scriptName || $profilePath === '') {
+            $base = rtrim(defined('BASE_URL') ? BASE_URL : '', '/');
+            $profilePath = ($base !== '' ? $base : '') . '/api/profile/show.php';
+        }
+        $profileUrl = $scheme . '://' . $host . rtrim($profilePath, '/');
+        $profileUrl .= '?id=' . urlencode((string)$user['id']);
+        $profileUrl .= '&role=' . urlencode(strtolower((string)$user['role']));
+
+        $profileResp = $this->httpGet($profileUrl, ['Accept: application/json']);
+        $profile = null;
+        if (is_array($profileResp)) {
+            $profile = $profileResp['profile'] ?? ($profileResp['user'] ?? null);
+        }
+
+        $this->json([
+            'status' => 'success',
+            'token' => $jwt,
+            'role' => (string)$user['role'],
+            'user_id' => (int)$user['id'],
+            'profile' => $profile ?? $meta,
+        ]);
+    }
+}

--- a/app/Controllers/Api/ProfileApiController.php
+++ b/app/Controllers/Api/ProfileApiController.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controllers\Api;
+
+use App\Core\DB;
+use App\Controllers\Auth\UserProviderFactory;
+
+final class ProfileApiController
+{
+    public function show(): void
+    {
+        $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+        $role = isset($_GET['role']) ? trim((string)$_GET['role']) : '';
+
+        header('Content-Type: application/json');
+
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'message' => 'Invalid id']);
+            exit;
+        }
+
+        $pdo = DB::conn();
+
+        if ($role !== '') {
+            $provider = UserProviderFactory::providerForRole(ucfirst(strtolower($role)));
+            if ($provider === null) {
+                http_response_code(404);
+                echo json_encode(['status' => 'error', 'message' => 'Unknown role']);
+                exit;
+            }
+            $meta = $provider->fetchMeta($pdo, $id);
+            echo json_encode(['status' => 'success', 'profile' => $meta]);
+            exit;
+        }
+
+        foreach (UserProviderFactory::providers() as $provider) {
+            try {
+                $meta = $provider->fetchMeta($pdo, $id);
+                if (!empty($meta)) {
+                    echo json_encode(['status' => 'success', 'profile' => $meta]);
+                    exit;
+                }
+            } catch (\Throwable $e) {
+                // ignore and try next provider
+            }
+        }
+
+        http_response_code(404);
+        echo json_encode(['status' => 'error', 'message' => 'Profile not found']);
+    }
+}

--- a/app/Services/AttemptService.php
+++ b/app/Services/AttemptService.php
@@ -8,7 +8,7 @@ use App\Core\DB;
 
 final class AttemptService
 {
-    private const MAX_ATTEMPTS = 3;
+    public const MAX_ATTEMPTS = 3;
     private const LOCK_MINUTES = 15;
 
     public function isLockedOut(PDO $pdo, string $email, string $ip): bool

--- a/app/Views/auth/api_demo.php
+++ b/app/Views/auth/api_demo.php
@@ -1,0 +1,68 @@
+<?php $base = defined('BASE_URL') ? BASE_URL : ''; ?>
+<section class="py-5">
+    <div class="container" style="max-width: 720px;">
+        <h1 class="h3 mb-3">Auth API Demo</h1>
+        <p class="text-muted">
+            Enter credentials to call <code>POST <?= htmlspecialchars($base) ?>/api/auth/login.php</code> and
+            inspect the JSON response returned by the API.
+        </p>
+
+        <div class="card shadow-sm mb-4">
+            <div class="card-body">
+                <div class="mb-3">
+                    <label class="form-label" for="demo-email">Email</label>
+                    <input class="form-control" id="demo-email" type="email" value="candidate@example.com">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="demo-password">Password</label>
+                    <input class="form-control" id="demo-password" type="password" value="password123">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="demo-role">Role (optional)</label>
+                    <select class="form-select" id="demo-role">
+                        <option value="">(auto-detect)</option>
+                        <option value="candidate">Candidate</option>
+                        <option value="employer">Employer</option>
+                        <option value="recruiter">Recruiter</option>
+                    </select>
+                </div>
+                <button class="btn btn-primary w-100" id="demo-btn" type="button">Call Login API</button>
+            </div>
+        </div>
+
+        <h2 class="h5">Response</h2>
+        <pre id="demo-output" class="bg-light border rounded p-3">No request yet.</pre>
+    </div>
+</section>
+<script>
+(() => {
+    const base = <?= json_encode($base) ?>;
+    const btn = document.getElementById('demo-btn');
+    const output = document.getElementById('demo-output');
+    if (!btn || !output) {
+        return;
+    }
+
+    btn.addEventListener('click', async () => {
+        output.textContent = 'Calling...';
+        const email = document.getElementById('demo-email').value.trim();
+        const password = document.getElementById('demo-password').value;
+        const role = document.getElementById('demo-role').value;
+
+        const body = JSON.stringify({ email, password, role });
+        const url = (base || '') + '/api/auth/login.php';
+
+        try {
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body,
+            });
+            const json = await res.json();
+            output.textContent = JSON.stringify(json, null, 2);
+        } catch (err) {
+            output.textContent = 'Request error: ' + err.message;
+        }
+    });
+})();
+</script>

--- a/public/api/auth/login.php
+++ b/public/api/auth/login.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use App\Controllers\Api\AuthApiController;
+
+require dirname(__DIR__, 3) . '/app/bootstrap.php';
+
+$controller = new AuthApiController();
+$controller->login();

--- a/public/api/profile/show.php
+++ b/public/api/profile/show.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+use App\Controllers\Api\ProfileApiController;
+
+require dirname(__DIR__, 3) . '/app/bootstrap.php';
+
+$controller = new ProfileApiController();
+$controller->show();


### PR DESCRIPTION
## Summary
- add AuthApiController and ProfileApiController to expose login and profile JSON endpoints
- create lightweight public entrypoints for the APIs and a front-end demo view
- make AttemptService::MAX_ATTEMPTS public so API responses can share lockout info

## Testing
- php -l app/Controllers/Api/AuthApiController.php
- php -l app/Controllers/Api/ProfileApiController.php
- php -l app/Views/auth/api_demo.php
- php -l public/api/auth/login.php
- php -l public/api/profile/show.php

------
https://chatgpt.com/codex/tasks/task_e_68d2bb702a008328b7719ae92d7b59eb