### PR TITLE
Add module fallback for admin moderation overview

### DIFF
--- a/app/Services/Admin/Moderation/Commands/OverviewCommand.php
+++ b/app/Services/Admin/Moderation/Commands/OverviewCommand.php
@@ -11,6 +11,7 @@ use App\Services\Admin\Moderation\ModerationCommand;
 use App\Services\Admin\Moderation\ModerationCommandResult;
 use App\Services\Admin\Moderation\ModerationSuspensionStore;
 use App\Services\Modules\ModuleRegistry;
+use Throwable;
 
 final class OverviewCommand implements ModerationCommand
 {
@@ -27,9 +28,23 @@ final class OverviewCommand implements ModerationCommand
 
     public function execute(): ModerationCommandResult
     {
-        $userSnapshot = $this->registry->call('user-management', 'users', 'all');
-        $jobSnapshot = $this->registry->call('job-application', 'summary', 'all');
-        $financeSnapshot = $this->registry->call('payment-billing', 'summary', 'all');
+        $userSnapshot = $this->snapshot('user-management', 'users', 'all');
+        $jobSnapshot = $this->snapshot('job-application', 'summary', 'all');
+        $financeSnapshot = $this->snapshot('payment-billing', 'summary', 'all');
+
+        $userData = $userSnapshot['data'] ?? [];
+        $jobData = $jobSnapshot['data'] ?? [];
+        $financeData = $financeSnapshot['data'] ?? [];
+
+        $userRecords = $userData['users'] ?? $userData;
+        if (!is_array($userRecords)) {
+            $userRecords = [];
+        }
+
+        $userCounts = $userData['counts'] ?? [];
+        if (!is_array($userCounts)) {
+            $userCounts = [];
+        }
 
         $pendingVerifications = Candidate::query()->where('verified_status', 'pending')->count();
         $flaggedJobs = JobPosting::query()->whereIn('status', ['flagged', 'under_review'])->count();
@@ -37,21 +52,54 @@ final class OverviewCommand implements ModerationCommand
 
         $suspensions = $this->suspensionStore?->count() ?? 0;
 
+        $errors = array_filter([
+            'user-management' => $userSnapshot['error'] ?? null,
+            'job-application' => $jobSnapshot['error'] ?? null,
+            'payment-billing' => $financeSnapshot['error'] ?? null,
+        ]);
+
         return new ModerationCommandResult(
             $this->name(),
             'success',
             [
                 'overview' => [
-                    'users' => $userSnapshot['users'] ?? $userSnapshot,
-                    'jobs' => $jobSnapshot['summary'] ?? [],
-                    'finance' => $financeSnapshot['summary'] ?? [],
+                    'users' => $userRecords,
+                    'user_counts' => $userCounts,
+                    'jobs' => $jobData['summary'] ?? $jobData,
+                    'finance' => $financeData['summary'] ?? $financeData,
                     'pending_verifications' => $pendingVerifications,
                     'flagged_jobs' => $flaggedJobs,
                     'failed_payments' => $failedPayments,
                     'active_suspensions' => $suspensions,
+                    'errors' => $errors,
                 ],
             ],
             'Overview generated.'
         );
+    }
+
+    /**
+     * @return array{data: array<string, mixed>|null, error: string|null}
+     */
+    private function snapshot(string $module, string $type, ?string $id = null): array
+    {
+        try {
+            return [
+                'data' => $this->registry->call($module, $type, $id),
+                'error' => null,
+            ];
+        } catch (Throwable $exception) {
+            error_log(sprintf(
+                '[Moderation][WARN] %s:%s snapshot failed: %s',
+                $module,
+                $type,
+                $exception->getMessage()
+            ));
+
+            return [
+                'data' => null,
+                'error' => sprintf('Failed to fetch %s snapshot.', $module),
+            ];
+        }
     }
 }

--- a/tests/Controllers/Api/AdminModerationApiRoutingTest.php
+++ b/tests/Controllers/Api/AdminModerationApiRoutingTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Controllers\Api\ResourceController;
+use App\Core\Request;
+use App\Services\Modules\ModuleRegistry;
+use App\Services\Modules\ModuleServiceInterface;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'App\\';
+    $baseDir = __DIR__ . '/../../../app/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\\\', '/', $relative) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});
+
+final class StubAdminModerationService implements ModuleServiceInterface
+{
+    public function name(): string
+    {
+        return 'admin-moderation';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return [
+            'module' => 'admin-moderation',
+            'type' => $type,
+            'id' => $id,
+        ];
+    }
+}
+
+final class StubUserManagementService implements ModuleServiceInterface
+{
+    public function name(): string
+    {
+        return 'user-management';
+    }
+
+    public function handle(string $type, ?string $id, Request $request): array
+    {
+        return ['module' => 'user-management'];
+    }
+}
+
+$request = new Request(
+    [],
+    [],
+    [],
+    [],
+    [
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI' => '/api/admin-moderation/overview',
+        'HTTP_ACCEPT' => 'application/json',
+        'REMOTE_ADDR' => '127.0.0.1',
+    ]
+);
+
+$registry = new ModuleRegistry();
+$registry->register(new StubAdminModerationService());
+$registry->register(new StubUserManagementService());
+
+$controller = new ResourceController();
+$controller->setModuleRegistry($registry);
+
+$response = $controller->show($request, 'admin-moderation', 'overview');
+
+assert($response->status() === 200, 'Module fallback should return a successful response.');
+
+$payload = json_decode($response->body(), true);
+if (!is_array($payload)) {
+    throw new RuntimeException('Module fallback response should be valid JSON.');
+}
+
+$assertedModule = $payload['data']['module'] ?? null;
+$assertedType = $payload['data']['type'] ?? null;
+
+assert($assertedModule === 'admin-moderation', 'Module fallback should expose the admin moderation module key.');
+assert($assertedType === 'overview', 'Module fallback should forward the requested operation.');
+
+echo "Admin moderation API routing test passed\n";

--- a/tests/Services/Admin/Moderation/ModerationCommandsTest.php
+++ b/tests/Services/Admin/Moderation/ModerationCommandsTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Services\Admin\Moderation\Commands\ApproveJobCommand;
+use App\Services\Admin\Moderation\Commands\AuditLogCommand;
+use App\Services\Admin\Moderation\Commands\OverviewCommand;
+use App\Services\Admin\Moderation\Commands\ReinstateUserCommand;
+use App\Services\Admin\Moderation\Commands\SuspendUserCommand;
+use App\Services\Admin\Moderation\ModerationSuspensionStore;
+use App\Services\Admin\Moderation\UserLookup;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
 require __DIR__ . '/../../../../vendor/autoload.php';
 
 spl_autoload_register(function (string $class): void {
@@ -19,12 +28,35 @@ spl_autoload_register(function (string $class): void {
     }
 });
 
-use App\Services\Admin\Moderation\Commands\ApproveJobCommand;
-use App\Services\Admin\Moderation\Commands\ReinstateUserCommand;
-use App\Services\Admin\Moderation\Commands\SuspendUserCommand;
-use App\Services\Admin\Moderation\ModerationSuspensionStore;
-use App\Services\Admin\Moderation\UserLookup;
-use Illuminate\Database\Capsule\Manager as Capsule;
+class StubModuleService implements \App\Services\Modules\ModuleServiceInterface
+{
+    /** @param array<string, array<string, mixed>|\Throwable> $responses */
+    public function __construct(
+        private string $moduleName,
+        private array $responses = []
+    ) {
+    }
+
+    public function name(): string
+    {
+        return $this->moduleName;
+    }
+
+    public function handle(string $type, ?string $id, \App\Core\Request $request): array
+    {
+        $key = strtolower($type) . ':' . ($id ?? '');
+        if (isset($this->responses[$key])) {
+            $response = $this->responses[$key];
+            if ($response instanceof \Throwable) {
+                throw $response;
+            }
+
+            return $response;
+        }
+
+        return ['module' => $this->moduleName];
+    }
+}
 
 $capsule = new Capsule();
 $capsule->addConnection([
@@ -45,7 +77,7 @@ $pdo->exec('CREATE TABLE job_postings (
     created_at TEXT,
     updated_at TEXT
 )');
-$pdo->exec("INSERT INTO job_postings (job_posting_id, company_id, status, created_at, updated_at) VALUES (1, 10, 'flagged', '2025-01-01 00:00:00', '2025-01-01 00:00:00')");
+$pdo->exec("INSERT INTO job_postings (job_posting_id, company_id, status, created_at, updated_at) VALUES (1, 2, 'flagged', '2025-01-01 00:00:00', '2025-01-01 00:00:00')");
 
 $pdo->exec('CREATE TABLE candidates (
     candidate_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -55,6 +87,19 @@ $pdo->exec('CREATE TABLE candidates (
     updated_at TEXT
 )');
 $pdo->exec("INSERT INTO candidates (candidate_id, full_name, email, created_at, updated_at) VALUES (1, 'Test Candidate', 'candidate@example.com', '2025-01-01 00:00:00', '2025-01-01 00:00:00')");
+$pdo->exec("ALTER TABLE candidates ADD COLUMN verified_status TEXT DEFAULT 'pending'");
+$pdo->exec("UPDATE candidates SET verified_status = 'pending' WHERE candidate_id = 1");
+
+$pdo->exec('CREATE TABLE payments (
+    payment_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    user_type TEXT,
+    amount REAL,
+    transaction_status TEXT,
+    created_at TEXT,
+    updated_at TEXT
+)');
+$pdo->exec("INSERT INTO payments (payment_id, user_id, user_type, amount, transaction_status, created_at, updated_at) VALUES (1, 3, 'employer', 250.00, 'failed', '2025-01-01 00:00:00', '2025-01-01 00:00:00')");
 
 $approve = new ApproveJobCommand(1, 42);
 $approveResult = $approve->execute();
@@ -82,6 +127,53 @@ $reinstate = new ReinstateUserCommand('candidate', 1, $store, $lookup, 99);
 $reinstateResult = $reinstate->execute();
 assert($reinstateResult->status() === 'success', 'ReinstateUserCommand should succeed.');
 assert($store->get('candidate', 1) === null, 'Suspension should be cleared after reinstatement.');
+
+$pdo->exec("UPDATE job_postings SET status = 'flagged'");
+
+$store->suspend('candidate', 2, null, null, 1001);
+
+$registry = new \App\Services\Modules\ModuleRegistry();
+$registry->register(new StubModuleService('user-management', [
+    'users:all' => [
+        'users' => [
+            'candidates' => [['candidate_id' => 1, 'email' => 'candidate@example.com']],
+        ],
+        'counts' => ['total' => 1],
+    ],
+    'user:1' => ['user' => ['candidate_id' => 1, 'email' => 'candidate@example.com']],
+    'user:2' => ['user' => ['employer_id' => 2, 'company_name' => 'Acme Corp']],
+    'user:3' => new RuntimeException('Payment owner lookup failed'),
+]));
+$registry->register(new StubModuleService('job-application', [
+    'summary:all' => [
+        'summary' => [
+            'jobs' => ['total' => 1],
+            'applications' => ['total' => 1],
+        ],
+    ],
+]));
+$registry->register(new StubModuleService('payment-billing', [
+    'summary:all' => new RuntimeException('Billing snapshot unavailable'),
+]));
+
+$overview = new OverviewCommand($registry, $store);
+$overviewResult = $overview->execute();
+$overviewData = $overviewResult->data()['overview'] ?? [];
+assert($overviewResult->status() === 'success', 'OverviewCommand should succeed even when a snapshot fails.');
+assert($overviewData['pending_verifications'] === 1, 'Pending verification count should include awaiting candidates.');
+assert($overviewData['flagged_jobs'] === 1, 'Flagged jobs count should reflect flagged listings.');
+assert($overviewData['failed_payments'] === 1, 'Failed payments count should reflect failed transactions.');
+assert($overviewData['active_suspensions'] === 1, 'Active suspension count should reflect stored suspensions.');
+assert(($overviewData['user_counts']['total'] ?? 0) === 1, 'User snapshot should retain count metadata.');
+assert(isset($overviewData['errors']['payment-billing']), 'Overview response should surface snapshot failures.');
+
+$audit = new AuditLogCommand($registry, $store);
+$auditResult = $audit->execute();
+$auditData = $auditResult->data()['audit'] ?? [];
+assert(count($auditData['candidates']) === 1, 'Audit log should include pending candidates.');
+assert(($auditData['candidates'][0]['user']['candidate_id'] ?? null) === 1, 'Audit candidate entry should embed user details.');
+assert(($auditData['jobs'][0]['employer']['employer_id'] ?? null) === 2, 'Audit job entry should include employer details.');
+assert($auditData['payments'][0]['user'] === null, 'Audit payment entry should tolerate failed user lookups.');
 
 @unlink($tempStorePath);
 


### PR DESCRIPTION
## Summary
- cache a module registry inside the API resource controller and expose a setter for injecting test registries
- delegate GET /api/{resource}/{id} to the module gateway when the resource is a registered module, keeping JSON:API errors for unknown names
- add a regression test that exercises the admin moderation overview endpoint to ensure the fallback route now returns module data

## Testing
- php tests/Controllers/Api/AdminModerationApiRoutingTest.php
- php tests/Services/Admin/Moderation/ModerationCommandsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d39e6950648328bf743f968405fd33