### PR TITLE
Restore admin login support

### DIFF
--- a/app/Controllers/Auth/Providers/AdminProvider.php
+++ b/app/Controllers/Auth/Providers/AdminProvider.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controllers\Auth\Providers;
+
+use App\Controllers\Auth\UserProviderInterface;
+use PDO;
+
+final class AdminProvider implements UserProviderInterface
+{
+    public function getRole(): string
+    {
+        return 'Admin';
+    }
+
+    public function findByEmail(PDO $pdo, string $email): ?array
+    {
+        $st = $pdo->prepare('SELECT admin_id AS id, email, password_hash FROM admins WHERE email=:e LIMIT 1');
+        $st->execute([':e' => $email]);
+        $row = $st->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    public function fetchMeta(PDO $pdo, int $id): array
+    {
+        $st = $pdo->prepare('SELECT full_name, role, status FROM admins WHERE admin_id=:id LIMIT 1');
+        $st->execute([':id' => $id]);
+        $row = $st->fetch(PDO::FETCH_ASSOC) ?: [];
+
+        return [
+            'name' => $row['full_name'] ?? '',
+            'premium_badge' => 0,
+            'verified_status' => 0,
+            'role' => $row['role'] ?? null,
+            'status' => $row['status'] ?? null,
+        ];
+    }
+
+    public function create(PDO $pdo, array $data): bool
+    {
+        $now = date('Y-m-d H:i:s');
+        $st = $pdo->prepare(
+            'INSERT INTO admins (full_name, email, password_hash, role, status, created_at, updated_at)'
+            . ' VALUES (:n, :e, :p, :r, :s, :c, :u)'
+        );
+
+        return $st->execute([
+            ':n' => $data['full_name'] ?? '',
+            ':e' => $data['email'],
+            ':p' => $data['password_hash'],
+            ':r' => $data['role'] ?? 'Support',
+            ':s' => $data['status'] ?? 'Active',
+            ':c' => $now,
+            ':u' => $now,
+        ]);
+    }
+
+    public function updatePassword(PDO $pdo, string $email, string $newHash): bool
+    {
+        $q = $pdo->prepare('UPDATE admins SET password_hash=:p, updated_at=NOW() WHERE email=:e LIMIT 1');
+
+        return $q->execute([':p' => $newHash, ':e' => $email]);
+    }
+}

--- a/app/Controllers/Auth/UserProviderFactory.php
+++ b/app/Controllers/Auth/UserProviderFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controllers\Auth;
 
+use App\Controllers\Auth\Providers\AdminProvider;
 use App\Controllers\Auth\Providers\CandidateProvider;
 use App\Controllers\Auth\Providers\EmployerProvider;
 use App\Controllers\Auth\Providers\RecruiterProvider;
@@ -16,6 +17,7 @@ final class UserProviderFactory
     public static function providers(): array
     {
         return [
+            new AdminProvider(),
             new CandidateProvider(),
             new EmployerProvider(),
             new RecruiterProvider(),


### PR DESCRIPTION
## Summary
- add an AdminProvider that knows how to look up and manage admin records
- register the admin provider with the user provider factory so Super Admin emails can be resolved during login

## Testing
- php -l app/Controllers/Auth/Providers/AdminProvider.php

------
https://chatgpt.com/codex/tasks/task_e_68d507913d9883288eb4515e4cc1d7e2