### PR TITLE
Refactor admin guardian and arbiter roles

### DIFF
--- a/app/Services/Admin/AdminArbiterInterface.php
+++ b/app/Services/Admin/AdminArbiterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+/**
+ * The asynchronous arbiter role that fans out moderation decisions to the rest
+ * of the platform via events or webhooks.
+ */
+interface AdminArbiterInterface
+{
+    /**
+     * Queue an event for asynchronous dispatch.
+     *
+     * @param array<string, mixed> $payload
+     */
+    public function dispatch(string $event, array $payload = []): void;
+
+    /**
+     * Flush any queued events to their listeners.
+     */
+    public function flush(): void;
+}

--- a/app/Services/Admin/AdminGuardianInterface.php
+++ b/app/Services/Admin/AdminGuardianInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+/**
+ * The synchronous guardian role that enforces policy, moderation and audit
+ * checks for administrative interactions.
+ */
+interface AdminGuardianInterface
+{
+    /**
+     * Assert that the current actor may read from the given resource.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function assertRead(string $resource, array $context = []): void;
+
+    /**
+     * Assert that the current actor may write to the given resource.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function assertWrite(string $resource, array $context = []): void;
+
+    /**
+     * Record an audit event for informational purposes.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function audit(string $action, array $context = []): void;
+
+    /**
+     * Raise a flag for follow-up review.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function flag(string $resource, array $context = []): void;
+}

--- a/app/Services/Admin/AdminRoleAwareInterface.php
+++ b/app/Services/Admin/AdminRoleAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+interface AdminRoleAwareInterface
+{
+    public function setAdminRoles(AdminGuardianInterface $guardian, AdminArbiterInterface $arbiter): void;
+}

--- a/app/Services/Admin/AdminRoleAwareTrait.php
+++ b/app/Services/Admin/AdminRoleAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+final class AdminRoleDefaults
+{
+    private static ?DefaultAdminGuardian $guardian = null;
+    private static ?DefaultAdminArbiter $arbiter = null;
+
+    public static function guardian(): DefaultAdminGuardian
+    {
+        if (self::$guardian === null) {
+            self::$guardian = new DefaultAdminGuardian();
+        }
+
+        return self::$guardian;
+    }
+
+    public static function arbiter(): DefaultAdminArbiter
+    {
+        if (self::$arbiter === null) {
+            self::$arbiter = new DefaultAdminArbiter();
+        }
+
+        return self::$arbiter;
+    }
+}
+
+trait AdminRoleAwareTrait
+{
+    private ?AdminGuardianInterface $adminGuardian = null;
+    private ?AdminArbiterInterface $adminArbiter = null;
+
+    public function setAdminRoles(AdminGuardianInterface $guardian, AdminArbiterInterface $arbiter): void
+    {
+        $this->adminGuardian = $guardian;
+        $this->adminArbiter = $arbiter;
+    }
+
+    protected function adminGuardian(): AdminGuardianInterface
+    {
+        if ($this->adminGuardian === null) {
+            $this->adminGuardian = AdminRoleDefaults::guardian();
+        }
+
+        return $this->adminGuardian;
+    }
+
+    protected function adminArbiter(): AdminArbiterInterface
+    {
+        if ($this->adminArbiter === null) {
+            $this->adminArbiter = AdminRoleDefaults::arbiter();
+        }
+
+        return $this->adminArbiter;
+    }
+}

--- a/app/Services/Admin/DefaultAdminArbiter.php
+++ b/app/Services/Admin/DefaultAdminArbiter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
+use JsonException;
+use RuntimeException;
+use Throwable;
+
+final class DefaultAdminArbiter implements AdminArbiterInterface
+{
+    /** @var array<int, callable(string, array<string, mixed>): void> */
+    private array $listeners = [];
+
+    /** @var array<int, array{event: string, payload: array<string, mixed>}> */
+    private array $queue = [];
+
+    private string $logPath;
+
+    public function __construct(?callable $listener = null, ?string $logPath = null)
+    {
+        $this->logPath = $logPath ?? dirname(__DIR__, 3) . '/storage/moderation/arbiter-events.log';
+        $this->registerListener(fn (string $event, array $payload): void => $this->writeLog($event, $payload));
+
+        if ($listener !== null) {
+            $this->registerListener($listener);
+        }
+    }
+
+    public function dispatch(string $event, array $payload = []): void
+    {
+        $this->queue[] = ['event' => $event, 'payload' => $payload];
+    }
+
+    public function flush(): void
+    {
+        while ($this->queue !== []) {
+            $current = array_shift($this->queue);
+            if ($current === null) {
+                continue;
+            }
+
+            foreach ($this->listeners as $listener) {
+                try {
+                    $listener($current['event'], $current['payload']);
+                } catch (Throwable $exception) {
+                    error_log(sprintf(
+                        'Admin arbiter listener failure for "%s": %s',
+                        $current['event'],
+                        $exception->getMessage()
+                    ));
+                }
+            }
+        }
+    }
+
+    public function registerListener(callable $listener): void
+    {
+        $this->listeners[] = $listener;
+    }
+
+    private function writeLog(string $event, array $payload): void
+    {
+        $record = [
+            'event' => $event,
+            'payload' => $payload,
+            'dispatched_at' => (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(DateTimeInterface::ATOM),
+        ];
+
+        $dir = dirname($this->logPath);
+        if (!is_dir($dir) && !mkdir($dir, 0777, true) && !is_dir($dir)) {
+            throw new RuntimeException('Unable to create moderation event directory.');
+        }
+
+        try {
+            $json = json_encode($record, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (JsonException $exception) {
+            throw new RuntimeException('Unable to encode admin arbiter event.', 0, $exception);
+        }
+
+        file_put_contents($this->logPath, $json . PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+
+    public function __destruct()
+    {
+        $this->flush();
+    }
+}

--- a/app/Services/Admin/DefaultAdminGuardian.php
+++ b/app/Services/Admin/DefaultAdminGuardian.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Services\Admin\Moderation\ErrorLogModerationLogger;
+use App\Services\Admin\Moderation\ModerationAuthorizationException;
+use App\Services\Admin\Moderation\ModerationLoggerInterface;
+use App\Services\Admin\Moderation\ModerationSuspensionStore;
+use DateTimeImmutable;
+use DateTimeZone;
+use Throwable;
+
+final class DefaultAdminGuardian implements AdminGuardianInterface
+{
+    public function __construct(
+        private readonly ModerationSuspensionStore $suspensions = new ModerationSuspensionStore(),
+        private readonly ModerationLoggerInterface $logger = new ErrorLogModerationLogger()
+    ) {
+    }
+
+    public function assertRead(string $resource, array $context = []): void
+    {
+        $this->audit(sprintf('read:%s', $resource), $context);
+        $this->guardAgainstSuspension($context, $resource, 'read');
+    }
+
+    public function assertWrite(string $resource, array $context = []): void
+    {
+        $this->audit(sprintf('write:%s', $resource), $context);
+        $this->guardAgainstSuspension($context, $resource, 'write');
+    }
+
+    public function audit(string $action, array $context = []): void
+    {
+        $this->logger->info('admin.guardian.' . $action, $context);
+    }
+
+    public function flag(string $resource, array $context = []): void
+    {
+        $this->logger->error(sprintf('admin.guardian.flag:%s', $resource), $context);
+    }
+
+    private function guardAgainstSuspension(array $context, string $resource, string $operation): void
+    {
+        $role = $this->normaliseRole($context['actor_role'] ?? $context['role'] ?? null);
+        $userId = $this->normaliseId($context['actor_id'] ?? $context['user_id'] ?? null);
+        if ($role === null || $userId === null) {
+            return;
+        }
+
+        $record = $this->suspensions->get($role, $userId);
+        if ($record === null) {
+            return;
+        }
+
+        if ($this->suspensionExpired($record)) {
+            $this->suspensions->reinstate($role, $userId);
+            $this->logger->info('admin.guardian.suspension-expired', [
+                'role' => $role,
+                'user_id' => $userId,
+                'resource' => $resource,
+                'operation' => $operation,
+            ] + $context);
+            return;
+        }
+
+        $this->logger->error('admin.guardian.blocked', [
+            'role' => $role,
+            'user_id' => $userId,
+            'resource' => $resource,
+            'operation' => $operation,
+            'suspension' => $record,
+        ] + $context);
+
+        throw new ModerationAuthorizationException('This action is blocked pending administrative review.');
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    private function suspensionExpired(array $record): bool
+    {
+        $expiresAt = $record['until'] ?? null;
+        if (!is_string($expiresAt) || trim($expiresAt) === '') {
+            return false;
+        }
+
+        try {
+            $until = new DateTimeImmutable($expiresAt, new DateTimeZone('UTC'));
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $until < new DateTimeImmutable('now', new DateTimeZone('UTC'));
+    }
+
+    private function normaliseRole(mixed $value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        return $trimmed === '' ? null : strtolower($trimmed);
+    }
+
+    private function normaliseId(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (is_string($value) && ctype_digit($value)) {
+            $int = (int) $value;
+            return $int > 0 ? $int : null;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated admin guardian and arbiter interfaces with default implementations and a trait to share them across modules via the registry
- extend the base module service with request-driven admin context helpers so feature modules can enforce guardian checks and audit metadata
- update moderation, user, job, payment, and resume services to assert guardian policy on reads/writes and dispatch arbiter events after moderation outcomes

## Testing
- composer dump-autoload
- vendor/bin/phpunit *(fails: executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d54f6638d48328abd8392e517954c2