### PR TITLE
Fix admin arbiter listener registration

### DIFF
--- a/app/Services/Admin/DefaultAdminArbiter.php
+++ b/app/Services/Admin/DefaultAdminArbiter.php
@@ -24,7 +24,9 @@ final class DefaultAdminArbiter implements AdminArbiterInterface
     public function __construct(?callable $listener = null, ?string $logPath = null)
     {
         $this->logPath = $logPath ?? dirname(__DIR__, 3) . '/storage/moderation/arbiter-events.log';
-        $this->registerListener(fn (string $event, array $payload): void => $this->writeLog($event, $payload));
+        $this->registerListener(function (string $event, array $payload): void {
+            $this->writeLog($event, $payload);
+        });
 
         if ($listener !== null) {
             $this->registerListener($listener);


### PR DESCRIPTION
## Summary
- replace the default admin arbiter's arrow function listener with a standard closure to avoid returning a value from a void function

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5738b1a388328a439d8e49638cb55